### PR TITLE
Fix broken required-repo link and correct README inaccuracies (issue #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git clone https://github.com/StanLukuvka/H3-SPEED.git ComfyUI/custom_nodes/H3-SP
 
 After cloning, load one of these workflows via ComfyUI's workflow browser (Workflow → Open):
 
-- `video_minimax_h3_t2v_speed.json` — standard SPEED pipeline (sampler → decode → save)
+- `video_minimax_h3_t2v-SPEED.json` — standard SPEED pipeline (sampler → decode → save)
 - `sigma_harvest.json` — calibration pass: harvest residual spectrum from clean noise
 - `sigma_harvest_calibrated.json` — full pipeline: harvest → report → schedule node
 
@@ -48,7 +48,7 @@ SPEED reduces VRAM by running early denoising at lower resolution. The `noise_po
 | `direct_coarse` | Fresh noise per stage, standard SPEED | Default. Lower VRAM, standard quality. |
 | `coupled_full_grid` | Shared full-grid noise across all scales | Higher quality (better high-frequency coherence) at the cost of more VRAM. |
 
-Use `video_minimax_h3_t2v_speed.json` (direct_coarse) for the default path, or `video_minimax_h3_t2v_coupled.json` (coupled_full_grid) when quality matters more than memory.
+Use `video_minimax_h3_t2v-SPEED.json` (direct_coarse) for the default path, or `video_minimax_h3_t2v_coupled.json` (coupled_full_grid) when quality matters more than memory.
 
 ### Presets (default 20-step schedule)
 
@@ -77,7 +77,7 @@ H3-SPEED/
 │   ├── spectral.py            — resolution expansion math
 │   ├── flow.py                — sigma alignment, audio handling
 │   ├── harvest.py             — radial power spectrum + fitting
-│   └── tests/                 — 61 passing tests
+│   └── tests/                 — 8 test files
 ├── nodes/
 │   ├── sampler_node.py        — MiniMaxH3SPEEDSampler (main)
 │   └── helper_nodes/
@@ -92,7 +92,7 @@ H3-SPEED/
 │       ├── x0_fidelity_probe.py — debug: X0 fidelity probe
 │       └── av_reentry_oracle.py — debug: AV reentry schedule
 └── workflows/
-    ├── video_minimax_h3_t2v_speed.json     — standard SPEED pipeline
+    ├── video_minimax_h3_t2v-SPEED.json     — standard SPEED pipeline
     ├── sigma_harvest.json                  — calibration-only workflow
     └── sigma_harvest_calibrated.json       — harvest → report → schedule
 ```
@@ -103,11 +103,14 @@ H3-SPEED/
 uv run pytest minimax_h3_speed/tests/ -q
 ```
 
-**Current:** 74 tests passing across 5 test files:
+**Current:** 8 test files:
 - `test_dct.py` — DCT transform correctness
+- `test_debug_nodes.py` — helper node smoke tests
 - `test_flow.py` — sigma alignment, audio handling
 - `test_harvest.py` — power spectrum, fitting, callback
 - `test_integration.py` — end-to-end harvest→schedule→sample pipeline
+- `test_oracle.py` — AV reentry oracle
+- `test_sampler.py` — sampler node behavior
 - `test_spectral.py` — spectral expansion
 
 ### Helper Nodes

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ git clone https://github.com/StanLukuvka/H3-SPEED.git ComfyUI/custom_nodes/H3-SP
 # restart ComfyUI
 ```
 
-**Required:** MiniMax-H3 plugin ([ComfyUI-MiniMax-H3](https://github.com/StanLukuvka/ComfyUI-MiniMax-H3), requires ComfyUI 0.32.0+).
-
 ## Usage
 
 After cloning, load one of these workflows via ComfyUI's workflow browser (Workflow → Open):


### PR DESCRIPTION
# Fix broken required-repo link and correct README inaccuracies (issue #4)

## What this change does

This is a documentation-only change to `README.md`. It fixes two classes of
inaccuracy that misled users trying to install and run this ComfyUI node pack:

1. It removes a "Required:" line that linked to a repository
   (`StanLukuvka/ComfyUI-MiniMax-H3`) which has been renamed or deleted and now
   returns a 404. That dead link made the install instructions point at a
   project that no longer exists.

2. It corrects two facts in the docs that had drifted from the code:
   - The standard workflow file is spelled `video_minimax_h3_t2v-SPEED.json`
     (capital "SPEED"). The README had it as `video_minimax_h3_t2v_speed.json`
     (lowercase), which does not match the file on disk. The file
     `workflows/video_minimax_h3_t2v-SPEED.json` is confirmed present.
   - The tests section claimed "74 tests across 5 test files". The repo actually
     has 8 test files in `minimax_h3_speed/tests/`. The section now lists those
     8 files by name instead of a stale count.

## Why these edits were made

Issue #4 reported that the README's "Required" repository link was broken. While
fixing it, the surrounding install and test instructions were checked against
the repository contents, and the two mismatches above were corrected so the docs
match what a user will actually find on disk.

## What was left alone on purpose

The remaining clone URL in the install block points to
`github.com/StanLukuvka/H3-SPEED.git`. That repository is still reachable, so
the install steps continue to work and were not touched.

## How to verify locally

- The corrected workflow filename resolves to a real file:
  `workflows/video_minimax_h3_t2v-SPEED.json`.
- The 8 test files named in the README all exist under
  `minimax_h3_speed/tests/`: test_dct, test_debug_nodes, test_flow, test_harvest,
  test_integration, test_oracle, test_sampler, test_spectral.

## Commits

- `1bd995f` — remove the broken required-repo link (issue #4).
- `bfe8f8d` — fix the workflow filename and the test list in the README.

