### PR TITLE
docs: fix README to match main (broken link, test count, structure tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ git clone https://github.com/StanLukuvka/H3-SPEED.git ComfyUI/custom_nodes/H3-SP
 # restart ComfyUI
 ```
 
-**Required:** MiniMax-H3 plugin ([ComfyUI-MiniMax-H3](https://github.com/StanLukuvka/ComfyUI-MiniMax-H3), requires ComfyUI 0.32.0+).
-
 ## Usage
 
 After cloning, load one of these workflows via ComfyUI's workflow browser (Workflow → Open):
@@ -79,10 +77,13 @@ H3-SPEED/
 │   ├── spectral.py            — resolution expansion math
 │   ├── flow.py                — sigma alignment, audio handling
 │   ├── harvest.py             — radial power spectrum + fitting
-│   └── tests/                 — 61 passing tests
+│   ├── oracle.py              — straight-flow oracle for CPU-verified proofs
+│   └── tests/                 — 8 test files
 ├── nodes/
 │   ├── sampler_node.py        — MiniMaxH3SPEEDSampler (main)
+│   ├── common.py              — shared node plumbing
 │   └── helper_nodes/
+│       ├── sampler_speed.py   — SPEED as a ComfyUI SAMPLER node
 │       ├── sigma_harvest.py   — SigmaHarvest (calibration pass)
 │       ├── harvest_to_config.py — parse harvest JSON → report
 │       ├── schedule.py        — SpeedConfig planner
@@ -105,11 +106,14 @@ H3-SPEED/
 uv run pytest minimax_h3_speed/tests/ -q
 ```
 
-**Current:** 74 tests passing across 5 test files:
+**Current:** 8 test files:
 - `test_dct.py` — DCT transform correctness
+- `test_debug_nodes.py` — helper node smoke tests
 - `test_flow.py` — sigma alignment, audio handling
 - `test_harvest.py` — power spectrum, fitting, callback
 - `test_integration.py` — end-to-end harvest→schedule→sample pipeline
+- `test_oracle.py` — AV reentry oracle
+- `test_sampler.py` — sampler node behavior
 - `test_spectral.py` — spectral expansion
 
 ### Helper Nodes


### PR DESCRIPTION
## What this fixes

The README had drifted from `main`. Four inaccuracies, all against files that exist in `main`:

1. **Dead "Required:" link** — pointed at `ComfyUI-MiniMax-H3`, a repo that no longer exists. Removed.
2. **Structure tree said "61 passing tests"** — corrected to "8 test files" and added the three source files it had omitted (`minimax_h3_speed/oracle.py`, `nodes/common.py`, `nodes/helper_nodes/sampler_speed.py`).
3. **Test suite section said "74 tests across 5 test files"** — corrected to "8 test files", listing the two missing ones (`test_debug_nodes.py`, `test_oracle.py`, `test_sampler.py`).
4. All workflow references in the README resolve to files present in `main`.

## Scope

README.md only. No source changes, no workflow changes.

## Verification

- `git diff --name-only main..fix-readme-workflow-filename` → `README.md` only.
- Every workflow filename referenced in the README exists in `main`.