### PR TITLE
feat: Continuous SPEED Sigma Harvester (observational per-step spectral telemetry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ See the [evidence section](evidence/README.md) for what changes in generation.
 
 Workflow wires are the same for all three: `noise` → `guider` → `sigmas` → `latent_image` → `output_latent` → `VAE Decode`.
 
+## Diagnostics — three different tools
+
+- **Sigma Harvest (Native Euler)** runs one native full-res Euler pass and outputs one aggregate residual calibration (`A / β`) to paste into Automatic.
+- **Sigma Trace (Per-Step Telemetry)** runs one native full-res Euler pass and records per-step x0 statistics with normalized low/mid/high band powers.
+- **SPEED Sigma Harvest (Continuous)** runs a normal SPEED generation but records the model's spectral state at every denoising step. It reports both the residual spectrum used by this project's existing empirical calibration and the denoised/x0 spectrum used by SPEED's theoretical power-spectrum model. This node is observational only. It does not currently move stage transitions during generation. See [docs/SPEED_SIGMA_HARVEST.md](docs/SPEED_SIGMA_HARVEST.md) for the output schema and how to read it.
+
+These are three distinct diagnostics: Sigma Harvest is not SPEED Sigma Harvest, and Sigma Trace is not SPEED Sigma Harvest. Only the continuous one runs the real multi-stage SPEED chain, and only it measures absolute (not normalized) per-step spectra.
+
 ## Speed Improvements
 
 Same 10s 0.5MP "world's most mediocre boss" office mug clip, same seed:
@@ -75,6 +83,8 @@ Same 10s 0.5MP "world's most mediocre boss" office mug clip, same seed:
 
 `direct_coarse` = fastest. `coupled_full_grid` = ~30-50% slower, can rescue 3-stage text. 
 See [evidence/README.md](evidence/README.md) for full 10s GIFs (360p 12fps) and mp4s.
+
+⚠️ **Old benchmark warning:** the 3/4-stage timings and quality notes above (and the matching evidence tables) predate the global transition-schedule fix (PR #37). Under the old scheduler, stages did not run where the configuration said they would, so that evidence must be rerun before being compared against anything new. The SPEED Sigma Harvest (Continuous) diagnostic must only be interpreted on the corrected (post-PR-#37) scheduler.
 
 **Rule of thumb:** Use `stages 2`. Try `3` if the quality holds, or use the conservative settings.
 

--- a/__init__.py
+++ b/__init__.py
@@ -45,11 +45,14 @@ def _register(_mod, _name):
 # sampler_node = automatic (delta_custom, baked A7.394 b0.62)
 # sampler_node_manual = manual (explicit step-through, 4 goal/res pairs)
 # sampler_sigma_harvest_node = native-Euler power-law calibration
+# sampler_sigma_trace_node = native-Euler per-step telemetry
+# sampler_speed_sigma_harvest_node = continuous SPEED sigma harvest (observer collector)
 _NODE_MODULES = (
     "sampler_node",
     "sampler_node_manual",
     "sampler_sigma_harvest_node",
     "sampler_sigma_trace_node",
+    "sampler_speed_sigma_harvest_node",
 )
 
 for _name in _NODE_MODULES:

--- a/docs/SPEED_SIGMA_HARVEST.md
+++ b/docs/SPEED_SIGMA_HARVEST.md
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED
 # SPEED Sigma Harvest (Continuous) — measurement reference
 
 `SPEED Sigma Harvest (Continuous)` is the node

--- a/docs/SPEED_SIGMA_HARVEST.md
+++ b/docs/SPEED_SIGMA_HARVEST.md
@@ -96,7 +96,6 @@ Each `records[]` entry (per measured callback):
   "stage_index": 1,
   "stage_scale": 0.5,
   "stage_local_step": 2,
-  "video_shape": [1, 24, 31, 23, 40],
   "sigma": {
     "actual": 0.621,
     "actual_next": 0.58,
@@ -174,8 +173,9 @@ Eligibility and EMA: `eligible_point` / `eligible_band` / `eligible_ema`
 answer, per step, whether the live x0 spectrum would already make the stage
 eligible to expand if it were controlling SPEED
 (`actual_sigma <= threshold`). `ema_power` is a log-space exponential moving
-average of the raw boundary power, seeded from the first valid x0 measurement
-of the run. It is recorded for study only.
+average of the raw boundary power, tracked per stage: each stage's EMA is
+seeded from that stage's first valid x0 measurement of the run, never from
+the static calibration coefficients. It is recorded for study only.
 
 Transitions: each `transitions[]` entry records one real resolution change
 (`from_stage`, `to_stage`, `global_schedule_index`, scales, ratio,

--- a/docs/SPEED_SIGMA_HARVEST.md
+++ b/docs/SPEED_SIGMA_HARVEST.md
@@ -1,0 +1,248 @@
+# FLOW-PRODUCED
+# SPEED Sigma Harvest (Continuous) — measurement reference
+
+`SPEED Sigma Harvest (Continuous)` is the node
+`MiniMax H3 SPEED — SPEED Sigma Harvest (Continuous)`
+(`nodes/sampler_speed_sigma_harvest_node.py`). It runs one real multi-stage
+SPEED generation and records the model's spectral state at every denoising
+step. It is observational only: it does not move stage transitions during
+generation.
+
+This document defines what the node measures, what the output JSON contains,
+how to read it, and what it cannot tell you.
+
+## Three different diagnostics
+
+The pack has three diagnostics with different jobs. They are not interchangeable:
+
+| Node | Generation | Measurement |
+|---|---|---|
+| Sigma Harvest (`MiniMaxH3HarvestToConfig`) | native full-res Euler | one aggregate residual calibration (`A` / `beta`) to paste into Automatic |
+| Sigma Trace (`MiniMaxH3SigmaTrace`) | native full-res Euler | per-step x0 telemetry with normalized low/mid/high bands |
+| SPEED Sigma Harvest (Continuous) | real multi-stage SPEED | per-step absolute spectra, stage-aware, both x0 and residual |
+
+Sigma Trace's bands are normalized to sum to 1. Normalized proportions are
+useful telemetry, but they discard absolute signal strength, which the SPEED
+activation equation needs. The continuous harvester measures absolute radial
+DCT power.
+
+## The two measurement bases
+
+Every measured step records two spectra under separate JSON namespaces:
+
+- `x0_signal` — the DCT power spectrum of the model's `denoised` prediction.
+  This is the paper's `P_omega = E[|x0^(omega)|^2]` on clean data. It is the
+  theoretically relevant quantity for the delta-optimal activation equation.
+- `residual` — the DCT power spectrum of `x_current - x0`. This is the same
+  basis the existing native Sigma Harvest calibrates on. Its per-step `A` /
+  `beta` values are directly comparable to that calibration.
+
+Both names carry the fitted coefficients (`x0_signal.fit.A`,
+`residual.fit.A`, ...), so no number in the JSON is ambiguous about which
+spectrum it came from.
+
+The baked Automatic defaults (`noise_amplitude=7.394`,
+`noise_decay_exponent=0.62`) come from the residual basis. They are an
+empirical H3 residual calibration, not the paper's clean-data power spectrum.
+The continuous harvester never seeds its x0 statistics from those coefficients.
+
+## Output JSON schema
+
+Top level (v1 schema):
+
+```json
+{
+  "schema_version": 1,
+  "type": "minimax_h3_speed_sigma_harvest",
+  "mode": "observational",
+  "adaptive_control": false,
+  "measurement_bases": ["denoised_x0_video", "residual_x_minus_x0_video"],
+  "sampler": "euler",
+  "static_scheduler": {
+    "stages": 4,
+    "scales": [0.25, 0.5, 0.75, 1.0],
+    "delta": 0.01,
+    "noise_amplitude": 7.394,
+    "noise_decay_exponent": 0.62,
+    "resolved_transition_steps": [3, 5, 8],
+    "original_sigmas": []
+  },
+  "analysis": {
+    "stride": 1,
+    "smoothing_alpha": 0.25,
+    "boundary_band_half_width": 1.0,
+    "fit_omega_min": 0.5,
+    "fit_omega_max_policy": "half_min_current_stage",
+    "measurement_mode": "both",
+    "store_radial_profiles": false
+  },
+  "records": [],
+  "transitions": [],
+  "summary": {}
+}
+```
+
+`measurement_mode` is `both`, `x0_only`, or `residual_only`. When
+`store_radial_profiles` is off (default), records contain fitted/scalar
+telemetry only; with it on, each record also carries the 1D radial profile
+(small, CPU-side), which is useful for research plots at the cost of JSON size.
+
+Each `records[]` entry (per measured callback):
+
+```json
+{
+  "callback_index": 6,
+  "global_schedule_index": 6,
+  "stage_index": 1,
+  "stage_scale": 0.5,
+  "stage_local_step": 2,
+  "video_shape": [1, 24, 31, 23, 40],
+  "sigma": {
+    "actual": 0.621,
+    "actual_next": 0.58,
+    "original": 0.59,
+    "original_next": 0.55
+  },
+  "x0_signal": {
+    "fit": {
+      "status": "ok",
+      "A": 201.3,
+      "beta": 2.11,
+      "r_squared": 0.91,
+      "n_bins": 18,
+      "health": "good"
+    },
+    "current_boundary": {
+      "transition_index": 1,
+      "omega": 11.25,
+      "direct_available": true,
+      "power_point": 1.42,
+      "power_band_mean": 1.39,
+      "activation_threshold_point": 0.632,
+      "activation_threshold_band": 0.629,
+      "eligible_point": true,
+      "eligible_band": true,
+      "ema_power": 1.35,
+      "ema_threshold": 0.625,
+      "eligible_ema": true
+    },
+    "fit_predictions": [
+      {
+        "transition_index": 1,
+        "omega": 11.25,
+        "P": 1.37,
+        "threshold": 0.627,
+        "predicted_original_step": 6,
+        "measurement": "power_law_fit"
+      }
+    ]
+  },
+  "residual": {
+    "fit": {
+      "status": "ok",
+      "A": 7.8,
+      "beta": 0.67,
+      "r_squared": 0.63,
+      "n_bins": 18,
+      "health": "fair"
+    }
+  }
+}
+```
+
+Sigma values: after a transition aligns the working schedule
+(`working_sigmas[boundary] = aligned_sigma`), the next stage starts at an
+`actual` sigma that differs from the `original` input sigma. `actual` answers
+"what timestep is this stage really operating at"; `original` answers "where
+is this in the user's original scheduler trajectory". Both are recorded.
+
+Boundary power: `power_point` is the radial DCT power interpolated at the
+current stage's next transition frequency
+(`omega = stage_scale * min(full_H, full_W) / 2` — the frequency canonical
+SPEED uses for that transition). `power_band_mean` is the mean over a narrow
+radial band of half-width `boundary_band_half_width` around it. The point
+value is closest to the theory; the band value is a less noisy empirical
+signal. Both are stored; neither is silently substituted for the other.
+
+Direct vs extrapolated: the current stage can only directly observe
+frequencies its own resolution represents. `direct_available: true` marks a
+direct measurement; anything derived for future stages comes from the fitted
+power law and is labelled `measurement: "fit_extrapolation"`. Never read an
+extrapolated prediction as an observation.
+
+Eligibility and EMA: `eligible_point` / `eligible_band` / `eligible_ema`
+answer, per step, whether the live x0 spectrum would already make the stage
+eligible to expand if it were controlling SPEED
+(`actual_sigma <= threshold`). `ema_power` is a log-space exponential moving
+average of the raw boundary power, seeded from the first valid x0 measurement
+of the run. It is recorded for study only.
+
+Transitions: each `transitions[]` entry records one real resolution change
+(`from_stage`, `to_stage`, `global_schedule_index`, scales, ratio,
+`sigma_before_alignment`, `sigma_after_alignment`, `kappa`, source/target
+shapes). Coincident transitions each emit their own event even when the
+intermediate stage runs zero denoising steps.
+
+Summary: per non-final stage — callback counts, the static planned transition
+step, the first live-eligible steps (direct raw / EMA / fit) with their
+difference from the static step, and first/last/min/max/mean of x0 and
+residual `A` / `beta` plus mean `r_squared`. Summaries operate on scalars;
+radial profiles are never averaged across stage resolutions.
+
+## How to interpret a run
+
+The experiment answers three questions:
+
+1. Does the residual fit move significantly during generation? If
+   `A_residual` / `beta_residual` are nearly constant across a run, the
+   static native Sigma Harvest calibration may already be sufficient.
+2. Does x0 boundary power move even when `A` / `beta` stay stable? If yes,
+   the global two-parameter fit is hiding useful local spectral behavior and
+   direct `P(omega)` measurement matters.
+3. Do live thresholds move transition timing by whole scheduler steps? A
+   threshold that drifts slightly is irrelevant if it quantizes to the same
+   static step every run. What matters is a consistent, repeatable gap, such
+   as static step 7 vs live step 5 across runs.
+
+Practical reading order per run: check `summary` first for the
+static-vs-live step gaps, then plot the per-step series (below) to see
+whether the signal is stable across seeds and prompts.
+
+## Plot suggestions
+
+For each run (2/3/4-stage, several seeds and prompts):
+
+- `A` / `beta` / `r_squared` vs global step, one series for `x0_signal.fit`
+  and one for `residual.fit`.
+- `current_boundary.power_point` and `current_boundary.ema_power` vs global
+  step (direct boundary power, raw and smoothed).
+- Static threshold vs live thresholds (direct point, band, EMA, fit) vs
+  global step.
+- Vertical markers at each entry of `transitions` (actual resolution changes).
+
+## Known limitations
+
+- Direct boundary measurement only exists at frequencies the current stage
+  can represent. Future-stage values are fit extrapolations, labelled as
+  such in the JSON.
+- The x0/residual EMA is observational. It never feeds back into the sampler.
+- The node cannot adapt transitions mid-stage: the whole stage sigma slice is
+  handed to `guider.sample()` before its callbacks run, so a "transition now"
+  measurement cannot stop a running stage. Same-run adaptive scheduling needs
+  a larger runtime rewrite (own the Euler loop) and is out of scope here.
+- Intermediate options exist if adaptive scheduling is later justified:
+  a one-`guider.sample()`-per-step prototype (simple, slow), or a two-pass
+  approach (harvest once, derive a schedule, rerun SPEED with it as a fixed
+  schedule). Owning the Euler loop in the SPEED runtime is the preferred
+  long-term architecture.
+- Spectral fits consume `P(omega)` through a two-parameter power law. If the
+  real spectrum bends, the fit-derived threshold diverges from the direct
+  measurement — that gap is exactly why both are recorded.
+
+## Old benchmark evidence
+
+3/4-stage evidence collected before the global transition fix (PR #37) must
+be rerun before it is compared against anything. Under the old scheduler the
+stages did not run where the configuration said they did, so telemetry from
+that period is contaminated. The continuous harvester must only be interpreted
+on the corrected scheduler.

--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §7 (commit 1) — flow-produced, do not hand-edit
 """Automatic SPEED sampler — uses LatentWalker to own the I2V keyframe
 lifecycle across the SPEED stage boundaries.
 

--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §7 (commit 1) — flow-produced, do not hand-edit
 """Automatic SPEED sampler — uses LatentWalker to own the I2V keyframe
 lifecycle across the SPEED stage boundaries.
 
@@ -11,27 +12,12 @@ from __future__ import annotations
 
 import comfy.samplers
 
-from speed_scripts.config import SpeedConfig
+from speed_scripts.automatic_config import (
+    PRESET_TO_STAGES,
+    build_automatic_speed_config,
+)
 from speed_scripts.h3_runtime import run_speed_pipeline
 from speed_scripts.latent_class import LatentWalker
-from speed_scripts.nodes_common import full_res_dims
-
-
-# Stages -> scale ladder for Automatic. Evenly spaced, ends at 1.0.
-# 2: 0.5 → 1.0, 3: 0.33 → 0.66 → 1.0, 4: 0.25 → 0.5 → 0.75 → 1.0
-STAGES_TO_SCALES: dict[int, tuple[float, ...]] = {
-    2: (0.5, 1.0),
-    3: (0.3333333333, 0.6666666667, 1.0),
-    4: (0.25, 0.5, 0.75, 1.0),
-}
-# Backwards compat: old preset names -> stages (for workflows saved before the rename)
-PRESET_TO_STAGES: dict[str, int] = {
-    "half_then_full": 2,
-    "three_quarter_then_full": 2,
-    "quarter_half_full": 3,
-    "aggressive": 3,
-    "quarter_half_3q_full": 4,
-}
 
 
 class MiniMaxH3SPEEDSampler:
@@ -83,7 +69,6 @@ class MiniMaxH3SPEEDSampler:
                 kwargs.get("Tolerance",
                 kwargs.get("tolerance",
                 kwargs.get("delta", kwargs.get("Delta", 0.01)))))
-        delta = float(delta)
         if "preset" in kwargs:
             preset = kwargs.pop("preset")
             stages = PRESET_TO_STAGES.get(preset, stages)
@@ -92,23 +77,14 @@ class MiniMaxH3SPEEDSampler:
         except Exception:
             stages = 3
         stages = max(2, min(4, stages))
-        scales = STAGES_TO_SCALES[stages]
-        # Dummy steps — validated then overridden by delta_custom power-spectrum thresholds
-        transition_steps = tuple(range(1, len(scales)))
-
-        # Resolve the live full-res dims, build the SpeedConfig.
-        full_h, full_w = full_res_dims(latent_image)
-        config = SpeedConfig(
-            scales=tuple(scales),
-            transition_steps=tuple(transition_steps),
-            transition_mode="delta_custom",
+        config = build_automatic_speed_config(
+            latent_image,
+            stages=stages,
             noise_policy=noise_policy,
-            delta=float(delta),
-            noise_amplitude=float(noise_amplitude),
-            noise_decay_exponent=float(noise_decay_exponent),
-            transition_seed_offset=int(seed_offset),
-            full_latent_h=full_h,
-            full_latent_w=full_w,
+            delta=delta,
+            noise_amplitude=noise_amplitude,
+            noise_decay_exponent=noise_decay_exponent,
+            seed_offset=seed_offset,
         )
 
         # Snapshot pristine for every keyframe/ref on the guider before the

--- a/nodes/sampler_sigma_harvest_node.py
+++ b/nodes/sampler_sigma_harvest_node.py
@@ -3,8 +3,13 @@
 Runs one native full-res Euler pass over the full sigma schedule using
 `guider.sample()` (not the SPEED chain), snapshots `residual = x - denoised`
 on each step, fits the radial DCT power spectrum `P = A * |omega|^(-beta)`,
-and emits a flat `calibration` JSON (noise_amplitude, noise_decay_exponent,
-delta, r2, health, report) to paste back into the Automatic node.
+and emits a flat `calibration` JSON (schema_version, noise_amplitude,
+noise_decay_exponent, delta, r2, health, measurement_basis,
+calibration_kind, report) to paste back into the Automatic node.
+
+The fit is an empirical H3 residual calibration (basis:
+`residual_x_minus_denoised`); its A/beta are not the clean-data power
+spectrum from the SPEED paper.
 """
 
 from __future__ import annotations
@@ -28,9 +33,11 @@ class MiniMaxH3HarvestToConfig:
 
     DESCRIPTION = (
         "Sigma Harvest — run this ONCE on a full-res native Euler generation to "
-        "calibrate the Automatic sampler. It measures how noise falls off with "
+        "calibrate the Automatic sampler. It is an empirical H3 residual "
+        "calibration: it measures how the residual (x - denoised) falls off with "
         "frequency (P = A·|ω|^-beta) and gives you A/beta to paste into the "
-        "Automatic node. Does NOT use SPEED — it must run at full res with a "
+        "Automatic node. It does NOT measure the clean-data power spectrum from "
+        "the SPEED paper. Does NOT use SPEED — it must run at full res with a "
         "fixed sigma schedule."
     )
     RETURN_TYPES = ("STRING", "LATENT")
@@ -233,16 +240,22 @@ class MiniMaxH3HarvestToConfig:
         # noise_amplitude / noise_decay_exponent + delta. No per-preset
         # transition_steps table — SPEED computes it via resolve_transition_steps.
         calibration = {
+            "schema_version": 2,
             "noise_amplitude": A,
             "noise_decay_exponent": beta,
             "delta": float(delta),
             "r2": r2,
             "health": health,
+            # Measurement basis: this fit comes from the residual (x - denoised),
+            # not the clean-data x0 spectrum. Kept alongside the original keys
+            # so existing consumers keep working unchanged.
+            "measurement_basis": "residual_x_minus_denoised",
+            "calibration_kind": "empirical_h3_residual_fit",
         }
 
         # Human-readable report — just the plug-and-play values
         lines = [
-            f"Calibrated: noise_amplitude={A:.3f}  noise_decay_exponent={beta:.3f}  r²={r2:.4f}  health={health}",
+            f"Empirical H3 residual calibration: noise_amplitude={A:.3f}  noise_decay_exponent={beta:.3f}  r²={r2:.4f}  health={health}",
         ]
         if health in ("suspect", "weak", "invalid"):
             lines.append(

--- a/nodes/sampler_speed_sigma_harvest_node.py
+++ b/nodes/sampler_speed_sigma_harvest_node.py
@@ -1,0 +1,139 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §4-6, 17, 48 (commit 4) — flow-produced, do not hand-edit
+"""SPEED Sigma Harvest (Continuous) — diagnostic node.
+
+Runs ONE real multi-stage SPEED generation (the same `run_speed_pipeline` the
+Automatic sampler uses, with the same shared config builder) and collects
+per-callback spectral telemetry through the runtime observer. Observational
+only: the generation is bit-for-bit identical to a run without the collector
+(the observer from commit 2 is the only runtime surface, and attaching one is
+behaviorally inert — proven by the commit-2 test suite).
+
+The collector lives in `speed_scripts.online_harvest`; this file is node
+wiring only.
+"""
+
+from __future__ import annotations
+
+import comfy.samplers
+import comfy.utils
+
+from speed_scripts.automatic_config import (
+    PRESET_TO_STAGES,
+    build_automatic_speed_config,
+)
+from speed_scripts.h3_runtime import run_speed_pipeline
+from speed_scripts.latent_class import LatentWalker
+from speed_scripts.online_harvest import SpeedHarvestCollector
+
+
+class MiniMaxH3SPEEDSigmaHarvest:
+    """Continuous SPEED Sigma Harvest — one SPEED run + per-step spectra.
+
+    Takes the Automatic sampler's generation inputs (same defaults, same
+    shared `build_automatic_speed_config`) plus a small diagnostic block,
+    and returns the harvest JSON alongside the normal SPEED outputs.
+    """
+
+    DESCRIPTION = (
+        "SPEED Sigma Harvest (Continuous) — runs a normal SPEED generation "
+        "but records the model's spectral state at every denoising step. "
+        "Reports both the residual spectrum used by this project's empirical "
+        "calibration and the denoised/x0 spectrum used by SPEED's theoretical "
+        "power-spectrum model. Observational only: stage transitions are not "
+        "moved during generation."
+    )
+    RETURN_TYPES = ("STRING", "LATENT", "LATENT")
+    RETURN_NAMES = ("harvest_json", "output", "denoised_output")
+    FUNCTION = "sample"
+    CATEGORY = "sampling/minimax_h3_speed/diagnostics"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "noise": ("NOISE",),
+                "guider": ("GUIDER",),
+                "sigmas": ("SIGMAS",),
+                "latent_image": ("LATENT",),
+                "stages": ("INT", {"default": 3, "min": 2, "max": 4}),
+                "noise_policy": (["direct_coarse", "coupled_full_grid"], {"default": "direct_coarse"}),
+                "Tolerance (Delta)": ("FLOAT", {"default": 0.01, "min": 1e-4, "max": 0.5, "step": 0.001}),
+                "noise_amplitude": ("FLOAT", {"default": 7.394, "min": 0.0, "max": 1e6, "step": 0.001, "round": 0.001}),
+                "noise_decay_exponent": ("FLOAT", {"default": 0.62, "min": 0.0, "max": 10.0, "step": 0.001, "round": 0.001}),
+                "seed_offset": ("INT", {"default": 10000, "min": 0, "max": 2**31 - 1}),
+                "measurement_mode": (["both", "x0_only", "residual_only"], {"default": "both"}),
+                "analysis_stride": ("INT", {"default": 1, "min": 1, "max": 1000}),
+                "smoothing_alpha": ("FLOAT", {"default": 0.25, "min": 0.01, "max": 1.0, "step": 0.01}),
+                "boundary_band_half_width": ("FLOAT", {"default": 1.0, "min": 0.01, "max": 32.0, "step": 0.01}),
+                "store_radial_profiles": ("BOOLEAN", {"default": False}),
+            },
+        }
+
+    def sample(self, noise, guider, sigmas, latent_image, stages=3,
+               noise_policy="direct_coarse",
+               noise_amplitude=7.394, noise_decay_exponent=0.62,
+               seed_offset=10000,
+               measurement_mode="both", analysis_stride=1,
+               smoothing_alpha=0.25, boundary_band_half_width=1.0,
+               store_radial_profiles=False, **kwargs):
+        # Tolerance (Delta) is the UI label — same alias chain as the
+        # Automatic sampler so old workflows behave identically.
+        delta = kwargs.get("Tolerance (Delta)",
+                kwargs.get("Tolerance",
+                kwargs.get("tolerance",
+                kwargs.get("delta", kwargs.get("Delta", 0.01)))))
+        if "preset" in kwargs:
+            preset = kwargs.pop("preset")
+            stages = PRESET_TO_STAGES.get(preset, stages)
+        try:
+            stages = int(stages)
+        except Exception:
+            stages = 3
+        stages = max(2, min(4, stages))
+        config = build_automatic_speed_config(
+            latent_image,
+            stages=stages,
+            noise_policy=noise_policy,
+            delta=delta,
+            noise_amplitude=noise_amplitude,
+            noise_decay_exponent=noise_decay_exponent,
+            seed_offset=seed_offset,
+        )
+
+        collector = SpeedHarvestCollector(
+            delta=config.delta,
+            noise_amplitude=config.noise_amplitude,
+            noise_decay_exponent=config.noise_decay_exponent,
+            measurement_mode=measurement_mode,
+            analysis_stride=analysis_stride,
+            smoothing_alpha=smoothing_alpha,
+            boundary_band_half_width=boundary_band_half_width,
+            store_radial_profiles=store_radial_profiles,
+        )
+        collector.set_original_sigmas(sigmas)
+
+        # Same walker priming as the Automatic sampler: snapshot pristine
+        # keyframe/ref latents before the first stage boundary.
+        LatentWalker(guider)
+
+        output, denoised = run_speed_pipeline(
+            noise,
+            guider,
+            sigmas,
+            latent_image,
+            config,
+            sampler=comfy.samplers.sampler_object("euler"),
+            disable_pbar=not comfy.utils.PROGRESS_BAR_ENABLED,
+            output_device=None,
+            observer=collector,
+        )
+        return (collector.to_json(), output, denoised)
+
+
+NODE_CLASS_MAPPINGS = {"MiniMaxH3SPEEDSigmaHarvest": MiniMaxH3SPEEDSigmaHarvest}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "MiniMaxH3SPEEDSigmaHarvest": "MiniMax H3 SPEED — SPEED Sigma Harvest (Continuous)"
+}
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS",
+           "MiniMaxH3SPEEDSigmaHarvest"]

--- a/nodes/sampler_speed_sigma_harvest_node.py
+++ b/nodes/sampler_speed_sigma_harvest_node.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §4-6, 17, 48 (commit 4) — flow-produced, do not hand-edit
 """SPEED Sigma Harvest (Continuous) — diagnostic node.
 
 Runs ONE real multi-stage SPEED generation (the same `run_speed_pipeline` the

--- a/speed_scripts/automatic_config.py
+++ b/speed_scripts/automatic_config.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §7 (commit 1) — flow-produced, do not hand-edit
 """Shared automatic SPEED config construction.
 
 The Automatic SPEED sampler and the SPEED Sigma Harvest diagnostic node must

--- a/speed_scripts/automatic_config.py
+++ b/speed_scripts/automatic_config.py
@@ -1,0 +1,75 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §7 (commit 1) — flow-produced, do not hand-edit
+"""Shared automatic SPEED config construction.
+
+The Automatic SPEED sampler and the SPEED Sigma Harvest diagnostic node must
+build identical SpeedConfig values from the same widget inputs. This module
+owns that construction so the two nodes cannot drift: the stage->scale
+ladder and the SpeedConfig fields all live here, and both nodes call
+`build_automatic_speed_config`. The delta value arrives already
+alias-resolved — the widget-label alias handling stays in the node layer.
+"""
+
+from __future__ import annotations
+
+from speed_scripts.config import SpeedConfig
+from speed_scripts.nodes_common import full_res_dims
+
+
+# Stages -> scale ladder for Automatic. Evenly spaced, ends at 1.0.
+# 2: 0.5 → 1.0, 3: 0.33 → 0.66 → 1.0, 4: 0.25 → 0.5 → 0.75 → 1.0
+STAGES_TO_SCALES: dict[int, tuple[float, ...]] = {
+    2: (0.5, 1.0),
+    3: (0.3333333333, 0.6666666667, 1.0),
+    4: (0.25, 0.5, 0.75, 1.0),
+}
+# Backwards compat: old preset names -> stages (for workflows saved before the rename)
+PRESET_TO_STAGES: dict[str, int] = {
+    "half_then_full": 2,
+    "three_quarter_then_full": 2,
+    "quarter_half_full": 3,
+    "aggressive": 3,
+    "quarter_half_3q_full": 4,
+}
+
+
+def build_automatic_speed_config(
+    latent_image,
+    *,
+    stages,
+    noise_policy,
+    delta,
+    noise_amplitude,
+    noise_decay_exponent,
+    seed_offset,
+) -> SpeedConfig:
+    """Build the SpeedConfig the Automatic sampler runs today.
+
+    `stages` selects the scale ladder and must already be normalized to
+    2-4 (the caller clamps). The transition steps are dummies: in
+    delta_custom mode the runtime places the real boundaries from the
+    power-spectrum threshold, so only the count matters (one boundary
+    between each pair of stages). `delta` is the Tolerance (Delta)
+    widget value.
+    """
+    scales = STAGES_TO_SCALES[stages]
+    transition_steps = tuple(range(1, len(scales)))
+    full_h, full_w = full_res_dims(latent_image)
+    return SpeedConfig(
+        scales=tuple(scales),
+        transition_steps=transition_steps,
+        transition_mode="delta_custom",
+        noise_policy=noise_policy,
+        delta=float(delta),
+        noise_amplitude=float(noise_amplitude),
+        noise_decay_exponent=float(noise_decay_exponent),
+        transition_seed_offset=int(seed_offset),
+        full_latent_h=full_h,
+        full_latent_w=full_w,
+    )
+
+
+__all__ = [
+    "STAGES_TO_SCALES",
+    "PRESET_TO_STAGES",
+    "build_automatic_speed_config",
+]

--- a/speed_scripts/h3_runtime.py
+++ b/speed_scripts/h3_runtime.py
@@ -29,6 +29,12 @@ from .spectral import (
 log = logging.getLogger(__name__)
 
 from .latent_class import LatentClass, LatentStage, LatentWalker
+from .observer import (
+    SpeedRunEndEvent,
+    SpeedRunStartEvent,
+    SpeedStepEvent,
+    SpeedTransitionEvent,
+)
 
 
 # Per-pipeline-run walker, stashed on the guider so the same wrapper dict
@@ -252,6 +258,25 @@ def _wrap_preview_callback(stock_cb, capture_state, global_offset, global_total)
                 )
     return callback
 
+def _wrap_observer_callback(inner_cb, observer, event_fn):
+    """Compose the observer around an existing stage callback (plan §14).
+
+    Order per callback: capture x0 / forward stock preview + progress
+    (the inner `_wrap_preview_callback` wrapper) FIRST, then notify the
+    observer — the UI update must not wait on observer work. The observer
+    receives the exact callback x0/x the inner wrapper recorded; the
+    shared `x0_output` dict remains the single x0 source (plan §45).
+    """
+    if observer is None:
+        return inner_cb
+
+    def callback(step, x0, x, total_steps):
+        inner_cb(step, x0, x, total_steps)
+        observer.on_step(event_fn(step), x0, x)
+
+    return callback
+
+
 def _find_first_step_below(sigmas, threshold: float) -> int:
     """[Level 3] First index whose sigma <= threshold; len-1 if none."""
     ffsb_vals = [float(s) for s in sigmas]
@@ -301,6 +326,7 @@ def run_speed_pipeline(
     output_device=None,
     preview_callback=None,
     x0_output=None,
+    observer=None,
 ):
     """[Level 1] Run an N-stage progressive-resolution Euler chain (multi-stage SPEED).
 
@@ -319,6 +345,13 @@ def run_speed_pipeline(
     in offline tests and programmatic use. The shared `x0` dict (`x0_output`)
     is also forwarded so `denoised` is reconstructed exactly as in
     `SamplerCustomAdvanced`.
+
+    `observer` optionally receives runtime events (see `speed_scripts.observer`):
+    one `on_step` per actual denoising interval, one `on_transition` per
+    resolution transition (coincident transitions included — a zero-step
+    intermediate stage emits no step event but its transition still fires),
+    plus one `on_run_start` / `on_run_end` each. `None` (the default) runs
+    the pipeline exactly as before.
 
     Returns ``(output_latent, denoised_latent)``.
     """
@@ -422,6 +455,17 @@ def run_speed_pipeline(
     global_done = 0
     global_start = 0  # GLOBAL index the next stage begins at (into working_sigmas).
 
+    if observer is not None:
+        observer.on_run_start(SpeedRunStartEvent(
+            n_stages=n_stages,
+            scales=tuple(scales),
+            transition_steps=tuple(int(s) for s in transition_steps),
+            global_steps=global_total,
+            full_h=full_h,
+            full_w=full_w,
+            full_t=full_t,
+        ))
+
     for stage_idx in range(n_stages - 1):
         # Boundary for this stage: transition_steps[stage_idx] is a GLOBAL
         # index into the sigma schedule identifying where the NEXT scale
@@ -451,11 +495,40 @@ def run_speed_pipeline(
         # global timeline, so the bar runs continuously and preview bytes
         # flow through the same PROGRESS_BAR_HOOK every other ComfyUI node
         # uses. The wrapper writes x0 into the shared `x0_output` dict for
-        # `clock_reindex` audio and the denoised fallback.
-        callback = _wrap_preview_callback(
+        # `clock_reindex` audio and the denoised fallback. The observer
+        # wrapper composes AROUND that preview wrapper so the stock
+        # preview/progress update always runs before observer work.
+        preview_cb = _wrap_preview_callback(
             stock_cb, x0_output, global_done, global_total,
         )
         stage_sigmas = working_sigmas[global_start:global_end + 1]
+        stage_h, stage_w, stage_t = stage_hw_t[stage_idx]
+
+        def _step_event(stage_local_step, _stage_idx=stage_idx,
+                        _global_start=global_start, _stage_sigmas=stage_sigmas,
+                        _stage_scale=scales[stage_idx], _stage_h=stage_h,
+                        _stage_w=stage_w, _stage_t=stage_t,
+                        _callback_offset=global_done):
+            _global_index = _global_start + stage_local_step
+            return SpeedStepEvent(
+                callback_index=_callback_offset + stage_local_step,
+                stage_index=_stage_idx,
+                stage_scale=_stage_scale,
+                stage_local_step=stage_local_step,
+                global_schedule_index=_global_index,
+                actual_sigma=float(_stage_sigmas[stage_local_step]),
+                actual_sigma_next=float(_stage_sigmas[stage_local_step + 1]),
+                original_sigma=float(sigmas[_global_index]),
+                original_sigma_next=float(sigmas[_global_index + 1]),
+                stage_h=_stage_h,
+                stage_w=_stage_w,
+                stage_t=_stage_t,
+                full_h=full_h,
+                full_w=full_w,
+                full_t=full_t,
+            )
+
+        callback = _wrap_observer_callback(preview_cb, observer, _step_event)
         public = guider.sample(
             stage_start_pub,
             stage_start_latent,
@@ -489,6 +562,24 @@ def run_speed_pipeline(
         # Patch the boundary coordinate in the working schedule with the
         # aligned sigma (upstream: `scheduler.sigmas[end] = t_tilde`).
         working_sigmas[global_end] = new_q
+
+        if observer is not None:
+            observer.on_transition(SpeedTransitionEvent(
+                transition_index=stage_idx,
+                from_stage=stage_idx,
+                to_stage=stage_idx + 1,
+                global_schedule_index=global_end,
+                from_scale=scales[stage_idx],
+                to_scale=scales[stage_idx + 1],
+                scale_ratio=ratio,
+                sigma_before_alignment=rsp_q,
+                sigma_after_alignment=new_q,
+                kappa=kappa,
+                source_h=stage_hw_t[stage_idx][0],
+                source_w=stage_hw_t[stage_idx][1],
+                target_h=stage_hw_t[stage_idx + 1][0],
+                target_w=stage_hw_t[stage_idx + 1][1],
+            ))
 
         # DCT-expand the video (coupled or fresh band) and rescale by kappa.
         next_h, next_w, next_t = stage_hw_t[stage_idx + 1]
@@ -590,19 +681,55 @@ def run_speed_pipeline(
     walker = _get_or_create_walker(guider)
     walker.apply_final()
     _drop_walker(guider)
-    final_callback = _wrap_preview_callback(
+    final_preview_cb = _wrap_preview_callback(
         stock_cb, x0_output, global_done, global_total,
+    )
+    final_sigmas = working_sigmas[global_start:]
+
+    def _final_step_event(stage_local_step, _stage_idx=n_stages - 1,
+                          _global_start=global_start, _stage_sigmas=final_sigmas,
+                          _stage_scale=scales[n_stages - 1],
+                          _stage_h=fh, _stage_w=fw, _stage_t=stage_hw_t[n_stages - 1][2],
+                          _callback_offset=global_done):
+        _global_index = _global_start + stage_local_step
+        return SpeedStepEvent(
+            callback_index=_callback_offset + stage_local_step,
+            stage_index=_stage_idx,
+            stage_scale=_stage_scale,
+            stage_local_step=stage_local_step,
+            global_schedule_index=_global_index,
+            actual_sigma=float(_stage_sigmas[stage_local_step]),
+            actual_sigma_next=float(_stage_sigmas[stage_local_step + 1]),
+            original_sigma=float(sigmas[_global_index]),
+            original_sigma_next=float(sigmas[_global_index + 1]),
+            stage_h=_stage_h,
+            stage_w=_stage_w,
+            stage_t=_stage_t,
+            full_h=full_h,
+            full_w=full_w,
+            full_t=full_t,
+        )
+
+    final_callback = _wrap_observer_callback(
+        final_preview_cb, observer, _final_step_event,
     )
     final_public = guider.sample(
         stage_start_pub,
         stage_start_latent,
         sampler,
-        working_sigmas[global_start:],
+        final_sigmas,
         callback=final_callback,
         disable_pbar=disable_pbar,
         seed=noise.seed,
     )
     last_public = final_public
+
+    if observer is not None:
+        observer.on_run_end(SpeedRunEndEvent(
+            n_stages=n_stages,
+            global_steps=global_total,
+            transition_count=n_stages - 1,
+        ))
 
     if output_device is not None and last_public is not None:
         last_public = last_public.to(output_device)

--- a/speed_scripts/h3_runtime.py
+++ b/speed_scripts/h3_runtime.py
@@ -529,6 +529,9 @@ def run_speed_pipeline(
             )
 
         callback = _wrap_observer_callback(preview_cb, observer, _step_event)
+        # H3-runtime behavior: a zero-step intermediate stage still invokes
+        # guider.sample once with a single-sigma schedule (zero denoising
+        # steps). Upstream SPEED skips the sampler for such segments.
         public = guider.sample(
             stage_start_pub,
             stage_start_latent,

--- a/speed_scripts/observer.py
+++ b/speed_scripts/observer.py
@@ -1,0 +1,117 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §8-12 (commit 2) — flow-produced, do not hand-edit
+"""Runtime observer contract for the multi-stage SPEED pipeline.
+
+`run_speed_pipeline` notifies an optional observer about what the run does:
+one event per actual denoising step, one event per resolution transition
+(coincident transitions included), and run start/end markers. The observer
+decides what to measure; this module imports nothing from the
+spectral-analysis code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class SpeedStepEvent:
+    """One actual denoising interval inside one SPEED stage.
+
+    `actual_sigma` / `actual_sigma_next` come from the working sigma
+    schedule the stage is consuming, so at a kappa-aligned re-entry they
+    differ from `original_sigma` / `original_sigma_next`, which index the
+    user's input schedule at the same global position.
+    """
+
+    callback_index: int
+    stage_index: int
+    stage_scale: float
+    stage_local_step: int
+
+    global_schedule_index: int
+
+    actual_sigma: float
+    actual_sigma_next: float
+
+    original_sigma: float
+    original_sigma_next: float
+
+    stage_h: int
+    stage_w: int
+    stage_t: int
+
+    full_h: int
+    full_w: int
+    full_t: int
+
+
+@dataclass(frozen=True)
+class SpeedTransitionEvent:
+    """One resolution transition, including coincident ones.
+
+    `sigma_before_alignment` is the working-schedule boundary value this
+    transition read (already aligned if a coincident earlier transition
+    patched it); `sigma_after_alignment` is the value written back.
+    """
+
+    transition_index: int
+
+    from_stage: int
+    to_stage: int
+
+    global_schedule_index: int
+
+    from_scale: float
+    to_scale: float
+    scale_ratio: float
+
+    sigma_before_alignment: float
+    sigma_after_alignment: float
+    kappa: float
+
+    source_h: int
+    source_w: int
+
+    target_h: int
+    target_w: int
+
+
+@dataclass(frozen=True)
+class SpeedRunStartEvent:
+    """Fired once before the first stage runs."""
+
+    n_stages: int
+    scales: tuple[float, ...]
+    transition_steps: tuple[int, ...]
+    global_steps: int
+    full_h: int
+    full_w: int
+    full_t: int
+
+
+@dataclass(frozen=True)
+class SpeedRunEndEvent:
+    """Fired once after the final stage completes."""
+
+    n_stages: int
+    global_steps: int
+    transition_count: int
+
+
+class SpeedRuntimeObserver(Protocol):
+    """Minimal observer interface implemented by SPEED telemetry collectors."""
+
+    def on_run_start(self, event: SpeedRunStartEvent) -> None: ...
+    def on_step(self, event: SpeedStepEvent, x0, x) -> None: ...
+    def on_transition(self, event: SpeedTransitionEvent) -> None: ...
+    def on_run_end(self, event: SpeedRunEndEvent) -> None: ...
+
+
+__all__ = [
+    "SpeedRunEndEvent",
+    "SpeedRunStartEvent",
+    "SpeedStepEvent",
+    "SpeedTransitionEvent",
+    "SpeedRuntimeObserver",
+]

--- a/speed_scripts/observer.py
+++ b/speed_scripts/observer.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §8-12 (commit 2) — flow-produced, do not hand-edit
 """Runtime observer contract for the multi-stage SPEED pipeline.
 
 `run_speed_pipeline` notifies an optional observer about what the run does:

--- a/speed_scripts/online_harvest.py
+++ b/speed_scripts/online_harvest.py
@@ -2,8 +2,9 @@
 
 Per-step companion to :mod:`speed_scripts.harvest`: measures the radial DCT
 power spectrum of a video tensor and fits ``P = A * |omega|^(-beta)`` without
-leaving the torch device, so a per-callback collector never pays for GPU
-sync or a ``.cpu().numpy()`` transfer. Also provides direct point/band
+leaving the torch device, so a per-callback collector avoids full per-step
+NumPy/profile transfers. Extracting Python scalars from the resulting
+tensors still synchronizes CUDA. Also provides direct point/band
 sampling of a radial profile, a log-space EMA for boundary-power smoothing,
 and JSON-safe fit records (failed fits become nulls, never NaN/Infinity).
 
@@ -171,7 +172,7 @@ def sample_radial_power(freqs: torch.Tensor, profile: torch.Tensor, omega: float
         return float(y[0])
     if omega >= float(x[-1]):
         return float(y[-1])
-    upper = int(torch.clamp(torch.searchsorted(x, torch.tensor(omega)), 1, x.numel() - 1))
+    upper = int(torch.clamp(torch.searchsorted(x, x.new_tensor(omega)), 1, x.numel() - 1))
     x0 = float(x[upper - 1])
     x1 = float(x[upper])
     y0 = float(y[upper - 1])
@@ -208,17 +209,20 @@ def update_log_ema(
 
     The first valid measurement seeds the EMA (plan §36 — never seed from the
     baked calibration A/beta). A non-positive ``raw`` carries no log-space
-    information and leaves the previous value unchanged. Returns the EMA in
-    linear power units.
+    information and leaves the previous value unchanged. ``alpha = 1.0``
+    disables smoothing: the EMA equals the raw measurement exactly. Returns
+    the EMA in linear power units.
     """
-    if not 0.0 < alpha < 1.0:
-        raise ValueError("alpha must be in (0, 1)")
+    if not 0.0 < alpha <= 1.0:
+        raise ValueError("alpha must be in (0, 1]")
     if raw <= 0:
         return previous_ema if previous_ema is not None else float("nan")
     if previous_ema is None:
         return float(raw)
     if previous_ema <= 0:
         raise ValueError("previous_ema must be positive once seeded")
+    if alpha == 1.0:
+        return float(raw)
     log_ema = (1.0 - alpha) * math.log(previous_ema) + alpha * math.log(raw)
     return math.exp(log_ema)
 
@@ -296,8 +300,8 @@ class SpeedHarvestCollector:
     ):
         if measurement_mode not in ("both", "x0_only", "residual_only"):
             raise ValueError(f"unsupported measurement_mode: {measurement_mode}")
-        if not 0.0 < smoothing_alpha < 1.0:
-            raise ValueError("smoothing_alpha must be in (0, 1)")
+        if not 0.0 < smoothing_alpha <= 1.0:
+            raise ValueError("smoothing_alpha must be in (0, 1]")
         if analysis_stride < 1:
             raise ValueError("analysis_stride must be >= 1")
         self.delta = float(delta)
@@ -451,18 +455,18 @@ class SpeedHarvestCollector:
             # Plan §21: fit only the canonical range, capped at half the
             # current stage's smaller spatial dimension, never DC.
             omega_max = min(event.stage_h, event.stage_w) / 2.0
+            freqs, profile = radial_dct_power_torch(x0_video)
             fit = fit_power_law_torch(
-                *radial_dct_power_torch(x0_video),
+                freqs, profile,
                 omega_min=DEFAULT_OMEGA_MIN,
                 omega_max=omega_max,
             )
             x0_block: dict[str, Any] = {"fit": build_fit_record(fit)}
-            boundary = self._boundary_block(event, x0_video)
+            boundary = self._boundary_block(event, freqs, profile)
             if boundary is not None:
                 x0_block["current_boundary"] = boundary
             x0_block["fit_predictions"] = self._fit_predictions(fit)
             if self.store_radial_profiles:
-                freqs, profile = radial_dct_power_torch(x0_video)
                 x0_block["radial_profile"] = {
                     "freqs": [float(v) for v in freqs.detach().cpu().tolist()],
                     "power": [float(v) for v in profile.detach().cpu().tolist()],
@@ -534,19 +538,19 @@ class SpeedHarvestCollector:
             block["ema_power"] = None
         return block
 
-    def _boundary_block(self, event, x0_video) -> dict[str, Any] | None:
+    def _boundary_block(self, event, freqs, profile) -> dict[str, Any] | None:
         """Direct boundary-power measurement for the stage's next transition.
 
         Plans §27-§31 (direct point/band power + live activation thresholds
         and eligibility) and §35 (per-stage log-space EMA of the raw x0
         boundary power, seeded from the stage's first valid measurement —
-        never from the static A/beta). ``None`` when the stage has no next
-        transition (final stage).
+        never from the static A/beta). Reads the stage's already-computed
+        radial profile. ``None`` when the stage has no next transition
+        (final stage).
         """
         omega = self._omega_boundary
         if omega is None:
             return None
-        freqs, profile = radial_dct_power_torch(x0_video)
         direct_available = bool(freqs.numel()) and omega <= float(freqs[-1])
         power_point = sample_radial_power(freqs, profile, omega)
         power_band = sample_radial_band_power(

--- a/speed_scripts/online_harvest.py
+++ b/speed_scripts/online_harvest.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §17-26, 30, 35, 42 (commits 3-4) — flow-produced, do not hand-edit
 """Torch-native online spectral analysis for continuous SPEED sigma harvesting.
 
 Per-step companion to :mod:`speed_scripts.harvest`: measures the radial DCT

--- a/speed_scripts/online_harvest.py
+++ b/speed_scripts/online_harvest.py
@@ -1,0 +1,272 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §17-24, 26, 30, 35, 42 (commit 3) — flow-produced, do not hand-edit
+"""Torch-native online spectral analysis for continuous SPEED sigma harvesting.
+
+Per-step companion to :mod:`speed_scripts.harvest`: measures the radial DCT
+power spectrum of a video tensor and fits ``P = A * |omega|^(-beta)`` without
+leaving the torch device, so a per-callback collector never pays for GPU
+sync or a ``.cpu().numpy()`` transfer. Also provides direct point/band
+sampling of a radial profile, a log-space EMA for boundary-power smoothing,
+and JSON-safe fit records (failed fits become nulls, never NaN/Infinity).
+
+Pure functions only — no node and no runtime wiring lives here.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from functools import lru_cache
+from typing import Any, NamedTuple
+
+import torch
+
+from .harvest import classify_fit_quality
+from .spectral import dct2
+
+# Plan §21: keep the lowest fitted bin just above DC. omega_min = 0.5 selects
+# every integer radial frequency >= 1 while excluding the DC bin (omega = 0),
+# and is never changed between stages.
+DEFAULT_OMEGA_MIN = 0.5
+
+# Plan §35 smoothing alpha for per-stage log-space EMAs.
+DEFAULT_SMOOTHING_ALPHA = 0.25
+
+
+class _RadialBinsKey(NamedTuple):
+    height: int
+    width: int
+    device_type: str
+    device_index: int | None
+
+
+@lru_cache(maxsize=64)
+def _cached_radial_bins(
+    height: int, width: int, device_type: str, device_index: int | None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    device = torch.device(device_type, device_index)
+    yy, xx = torch.meshgrid(
+        torch.arange(height, device=device, dtype=torch.float32),
+        torch.arange(width, device=device, dtype=torch.float32),
+        indexing="ij",
+    )
+    radial = torch.round(torch.sqrt(xx * xx + yy * yy)).to(torch.int64)
+    max_r = int(radial.max().item())
+    indices = radial.flatten()
+    counts = torch.bincount(indices, minlength=max_r + 1)
+    return indices, counts
+
+
+def _build_radial_bins(height: int, width: int, device: torch.device):
+    return _cached_radial_bins(height, width, device.type, device.index)
+
+
+def radial_dct_power_torch(video: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Mean 2D-DCT power of a video [B, C, T, H, W], binned radially on device.
+
+    Returns ``(freqs, profile)`` as 1-D float32 tensors on the input's device:
+    ``freqs`` are the non-empty integer radial frequencies in ascending order,
+    ``profile`` the mean squared DCT coefficient at each frequency. No element
+    of the computation touches NumPy or the CPU.
+    """
+    if video.ndim != 5:
+        raise ValueError(
+            f"radial_dct_power_torch expects a [B, C, T, H, W] video; got ndim={video.ndim}"
+        )
+    height, width = video.shape[-2], video.shape[-1]
+    coeffs = dct2(video.detach().float())
+    power = coeffs.square().mean(dim=(0, 1, 2))  # [H, W]
+
+    indices, counts = _build_radial_bins(height, width, video.device)
+    sums = torch.bincount(indices, weights=power.flatten(), minlength=counts.numel())
+    valid = counts > 0
+    freqs = torch.arange(counts.numel(), device=power.device, dtype=torch.float32)[valid]
+    profile = sums[valid] / counts[valid]
+    return freqs, profile
+
+
+def fit_power_law_torch(
+    freqs: torch.Tensor,
+    profile: torch.Tensor,
+    omega_min: float = DEFAULT_OMEGA_MIN,
+    omega_max: float | None = None,
+) -> dict[str, Any]:
+    """Fit ``P = A * omega^(-beta)`` by OLS in log-log space, torch-native.
+
+    Mirrors :func:`speed_scripts.harvest.fit_power_law`: same mask convention
+    (``omega >= omega_min`` and ``P > 0``), same R-squared, and the same
+    health classification thresholds via :func:`classify_fit_quality`. The
+    regression itself runs in float64 so results line up with the NumPy
+    fitter's float64 polyfit. ``omega_max`` caps the fit range from above
+    (plan §21: ``min(H_stage, W_stage) / 2``); the default keeps every
+    non-empty bin. Returns a dict with ``A``, ``beta``, ``r_squared``,
+    ``n_bins``, ``status``, and ``health``; a fit with too few bins or any
+    non-finite value gets ``status="fit_failed"`` with ``None`` numerics.
+    """
+    failed: dict[str, Any] = {
+        "status": "fit_failed",
+        "A": None,
+        "beta": None,
+        "r_squared": None,
+        "n_bins": 0,
+    }
+    freqs_f = freqs.detach().double()
+    profile_f = profile.detach().double()
+    if freqs_f.numel() == 0 or freqs_f.numel() != profile_f.numel():
+        return failed
+
+    mask = (freqs_f >= omega_min) & (profile_f > 0)
+    if omega_max is not None:
+        mask = mask & (freqs_f <= omega_max)
+    x = torch.log(freqs_f[mask])
+    y = torch.log(profile_f[mask])
+    if x.numel() < 3:
+        failed["n_bins"] = int(x.numel())
+        return failed
+
+    x_mean = x.mean()
+    y_mean = y.mean()
+    slope = ((x - x_mean) * (y - y_mean)).mean() / ((x - x_mean) ** 2).mean()
+    intercept = y_mean - slope * x_mean
+
+    pred = intercept + slope * x
+    ss_res = float(((y - pred) ** 2).sum())
+    ss_tot = float(((y - y_mean) ** 2).sum())
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+
+    fit = {
+        "A": math.exp(float(intercept)),
+        "beta": float(-slope),
+        "r_squared": r2,
+        "n_bins": int(x.numel()),
+    }
+    if not all(math.isfinite(fit[key]) for key in ("A", "beta", "r_squared")):
+        failed["n_bins"] = fit["n_bins"]
+        return failed
+    fit["status"] = "ok"
+    fit["health"] = classify_fit_quality(fit)
+    return fit
+
+
+def sample_radial_power(freqs: torch.Tensor, profile: torch.Tensor, omega: float) -> float:
+    """Point sample of a radial profile at ``omega`` by linear interpolation
+    between the neighboring bins (plan §30). Values below or above the measured
+    range clamp to the first or last bin instead of extrapolating.
+    """
+    if freqs.numel() == 0:
+        raise ValueError("cannot sample an empty radial profile")
+    x = freqs.detach().float()
+    y = profile.detach().float()
+    order = torch.argsort(x)
+    x = x[order]
+    y = y[order]
+    omega = float(omega)
+    if omega <= float(x[0]):
+        return float(y[0])
+    if omega >= float(x[-1]):
+        return float(y[-1])
+    upper = int(torch.clamp(torch.searchsorted(x, torch.tensor(omega)), 1, x.numel() - 1))
+    x0 = float(x[upper - 1])
+    x1 = float(x[upper])
+    y0 = float(y[upper - 1])
+    y1 = float(y[upper])
+    if x1 == x0:
+        return y0
+    t = (omega - x0) / (x1 - x0)
+    return y0 + t * (y1 - y0)
+
+
+def sample_radial_band_power(
+    freqs: torch.Tensor, profile: torch.Tensor, omega: float, half_width: float = 1.0
+) -> float:
+    """Narrow-band mean of a radial profile over ``[omega - half_width, omega + half_width]``.
+
+    Falls back to the interpolated point sample when no bin falls inside the
+    band, so a caller never gets an error for a band that is empty at the
+    current stage resolution.
+    """
+    if half_width <= 0:
+        raise ValueError("half_width must be positive")
+    x = freqs.detach().float()
+    y = profile.detach().float()
+    mask = (x >= omega - half_width) & (x <= omega + half_width)
+    if not bool(mask.any()):
+        return sample_radial_power(freqs, profile, omega)
+    return float(y[mask].mean())
+
+
+def update_log_ema(
+    previous_ema: float | None, raw: float, alpha: float = DEFAULT_SMOOTHING_ALPHA
+) -> float:
+    """One log-space EMA step: ``log_ema = (1-alpha)*log_prev + alpha*log(raw)``.
+
+    The first valid measurement seeds the EMA (plan §36 — never seed from the
+    baked calibration A/beta). A non-positive ``raw`` carries no log-space
+    information and leaves the previous value unchanged. Returns the EMA in
+    linear power units.
+    """
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be in (0, 1)")
+    if raw <= 0:
+        return previous_ema if previous_ema is not None else float("nan")
+    if previous_ema is None:
+        return float(raw)
+    if previous_ema <= 0:
+        raise ValueError("previous_ema must be positive once seeded")
+    log_ema = (1.0 - alpha) * math.log(previous_ema) + alpha * math.log(raw)
+    return math.exp(log_ema)
+
+
+def finite_or_none(value: Any) -> float | None:
+    """Convert to a finite float, or None for None/NaN/±Infinity (plan §42)."""
+    if value is None:
+        return None
+    result = float(value)
+    return result if math.isfinite(result) else None
+
+
+def build_fit_record(fit: dict[str, Any] | None) -> dict[str, Any]:
+    """JSON-safe record for one spectral fit (plan §42).
+
+    A missing or failed fit becomes ``{"status": "fit_failed", "A": null,
+    "beta": null, "r_squared": null}``; a successful fit carries finite
+    floats plus ``n_bins`` and ``health``. The result always survives
+    ``json.dumps(..., allow_nan=False)``.
+    """
+    failed: dict[str, Any] = {
+        "status": "fit_failed",
+        "A": None,
+        "beta": None,
+        "r_squared": None,
+    }
+    if fit is None:
+        return failed
+    record = {
+        "status": "ok",
+        "A": finite_or_none(fit["A"]),
+        "beta": finite_or_none(fit["beta"]),
+        "r_squared": finite_or_none(fit["r_squared"]),
+        "n_bins": int(fit["n_bins"]),
+    }
+    if any(record[key] is None for key in ("A", "beta", "r_squared")):
+        return failed
+    record["health"] = str(fit["health"])
+    return record
+
+
+def dumps_strict(document: dict[str, Any]) -> str:
+    """Serialize a harvest document with NaN/Infinity rejected (plan §42)."""
+    return json.dumps(document, allow_nan=False)
+
+
+__all__ = [
+    "DEFAULT_OMEGA_MIN",
+    "DEFAULT_SMOOTHING_ALPHA",
+    "radial_dct_power_torch",
+    "fit_power_law_torch",
+    "sample_radial_power",
+    "sample_radial_band_power",
+    "update_log_ema",
+    "finite_or_none",
+    "build_fit_record",
+    "dumps_strict",
+]

--- a/speed_scripts/online_harvest.py
+++ b/speed_scripts/online_harvest.py
@@ -1,4 +1,4 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §17-24, 26, 30, 35, 42 (commit 3) — flow-produced, do not hand-edit
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §17-26, 30, 35, 42 (commits 3-4) — flow-produced, do not hand-edit
 """Torch-native online spectral analysis for continuous SPEED sigma harvesting.
 
 Per-step companion to :mod:`speed_scripts.harvest`: measures the radial DCT
@@ -8,19 +8,27 @@ sync or a ``.cpu().numpy()`` transfer. Also provides direct point/band
 sampling of a radial profile, a log-space EMA for boundary-power smoothing,
 and JSON-safe fit records (failed fits become nulls, never NaN/Infinity).
 
-Pure functions only — no node and no runtime wiring lives here.
+Also hosts the `SpeedHarvestCollector` — the observer-side collector that turns
+SPEED runtime events into per-step telemetry records. No ComfyUI node lives
+here; the node wiring stays in nodes/.
 """
 
 from __future__ import annotations
 
 import json
 import math
+import time
 from functools import lru_cache
 from typing import Any, NamedTuple
 
 import torch
 
 from .harvest import classify_fit_quality
+from .h3_runtime import (
+    _find_first_step_below as first_step_below,
+    activation_threshold,
+    power_at_frequency,
+)
 from .spectral import dct2
 
 # Plan §21: keep the lowest fitted bin just above DC. omega_min = 0.5 selects
@@ -258,9 +266,542 @@ def dumps_strict(document: dict[str, Any]) -> str:
     return json.dumps(document, allow_nan=False)
 
 
+class SpeedHarvestCollector:
+    """Observer-side collector: SPEED runtime events -> telemetry records.
+
+    Implements the `SpeedRuntimeObserver` protocol (plan §9). The runtime
+    decides *what is happening* (stage slices, boundaries, sigma values);
+    this collector decides *what to measure*: per-callback absolute radial
+    DCT power of the x0 video and (mode permitting) the residual x - x0,
+    power-law fits, direct boundary-power estimates, live activation
+    thresholds, log-space EMA smoothing, and the JSON document (plans
+    §24-§41).
+
+    Tensor lifetime (plan §26, non-negotiable): every callback tensor is
+    received, reduced to Python scalars / small CPU lists, and dropped
+    before `on_step` returns. No tensor is ever appended to the records.
+    """
+
+    def __init__(
+        self,
+        *,
+        delta: float,
+        noise_amplitude: float,
+        noise_decay_exponent: float,
+        measurement_mode: str = "both",
+        analysis_stride: int = 1,
+        smoothing_alpha: float = DEFAULT_SMOOTHING_ALPHA,
+        boundary_band_half_width: float = 1.0,
+        store_radial_profiles: bool = False,
+        record_timing: bool = False,
+    ):
+        if measurement_mode not in ("both", "x0_only", "residual_only"):
+            raise ValueError(f"unsupported measurement_mode: {measurement_mode}")
+        if not 0.0 < smoothing_alpha < 1.0:
+            raise ValueError("smoothing_alpha must be in (0, 1)")
+        if analysis_stride < 1:
+            raise ValueError("analysis_stride must be >= 1")
+        self.delta = float(delta)
+        self.noise_amplitude = float(noise_amplitude)
+        self.noise_decay_exponent = float(noise_decay_exponent)
+        self.measurement_mode = measurement_mode
+        self.analysis_stride = int(analysis_stride)
+        self.smoothing_alpha = float(smoothing_alpha)
+        self.boundary_band_half_width = float(boundary_band_half_width)
+        self.store_radial_profiles = bool(store_radial_profiles)
+        # Plan §58: analysis_ms is recorded only when explicitly requested —
+        # honest timing needs a device sync, which itself changes performance.
+        self.record_timing = bool(record_timing)
+
+        self.records: list[dict[str, Any]] = []
+        self.transitions: list[dict[str, Any]] = []
+        self._static_scheduler: dict[str, Any] = {}
+        self._analysis_block: dict[str, Any] = {}
+        self._original_sigmas: list[float] = []
+        self._scales: list[float] = []
+        self._full_h = 0
+        self._full_w = 0
+        # (transition_index, omega) pairs this stage can still measure or
+        # predict: the current boundary first, then future boundaries.
+        self._future_omegas: list[tuple[int, float]] = []
+        self._omega_boundary: float | None = None
+        self._next_transition_index: int = 0
+        # Per-stage log-space EMAs, x0 and residual namespaces separate
+        # (plans §35, §37). Keyed by stage_index; each starts None and is
+        # seeded from the stage's FIRST valid measurement — never from the
+        # static calibration coefficients (plan §36).
+        self._ema_x0: dict[int, float | None] = {}
+        self._ema_residual: dict[int, float | None] = {}
+
+    # ------------------------------------------------------------------
+    # Observer protocol
+    # ------------------------------------------------------------------
+    def on_run_start(self, event) -> None:
+        self._scales = [float(s) for s in event.scales]
+        self._full_h = event.full_h
+        self._full_w = event.full_w
+        self._static_scheduler = {
+            "stages": event.n_stages,
+            "scales": self._scales,
+            "delta": self.delta,
+            "noise_amplitude": self.noise_amplitude,
+            "noise_decay_exponent": self.noise_decay_exponent,
+            "resolved_transition_steps": [int(s) for s in event.transition_steps],
+            "original_sigmas": list(self._original_sigmas),
+        }
+        self._analysis_block = {
+            "stride": self.analysis_stride,
+            "smoothing_alpha": self.smoothing_alpha,
+            "boundary_band_half_width": self.boundary_band_half_width,
+            "fit_omega_min": DEFAULT_OMEGA_MIN,
+            "fit_omega_max_policy": "half_min_current_stage",
+            "measurement_mode": self.measurement_mode,
+            "store_radial_profiles": self.store_radial_profiles,
+        }
+        self._arm_stage(0)
+
+    def on_step(self, event, x0, x) -> None:
+        if event.stage_local_step == 0:
+            # First measured callback of a stage re-arms the per-stage EMAs.
+            self._ema_x0.setdefault(event.stage_index, None)
+            self._ema_residual.setdefault(event.stage_index, None)
+
+        measured = event.callback_index % self.analysis_stride == 0
+        record: dict[str, Any] = {
+            "callback_index": event.callback_index,
+            "global_schedule_index": event.global_schedule_index,
+            "stage_index": event.stage_index,
+            "stage_scale": float(event.stage_scale),
+            "stage_local_step": event.stage_local_step,
+            "sigma": {
+                "actual": float(event.actual_sigma),
+                "actual_next": float(event.actual_sigma_next),
+                "original": float(event.original_sigma),
+                "original_next": float(event.original_sigma_next),
+            },
+        }
+        if not measured:
+            self.records.append(record)
+            return
+
+        x0_video = _video_stream(x0)
+        if self.measurement_mode != "x0_only":
+            # The residual needs both callback tensors; a missing x0 also
+            # blocks it (residual = x - x0).
+            x_video = _video_stream(x)
+            if x0_video is not None and x_video is not None:
+                record["residual"] = self._measure_residual(event, x0_video, x_video)
+            else:
+                record["residual"] = _error_record("missing video tensor")
+        if self.measurement_mode != "residual_only":
+            if x0_video is not None:
+                record["x0_signal"] = self._measure_x0(event, x0_video)
+            else:
+                record["x0_signal"] = _error_record("missing x0 video tensor")
+        self.records.append(record)
+
+    def on_transition(self, event) -> None:
+        self.transitions.append({
+            "transition_index": event.transition_index,
+            "from_stage": event.from_stage,
+            "to_stage": event.to_stage,
+            "global_schedule_index": event.global_schedule_index,
+            "from_scale": float(event.from_scale),
+            "to_scale": float(event.to_scale),
+            "ratio": float(event.scale_ratio),
+            "sigma_before_alignment": float(event.sigma_before_alignment),
+            "sigma_after_alignment": float(event.sigma_after_alignment),
+            "kappa": float(event.kappa),
+            "source_hw": [event.source_h, event.source_w],
+            "target_hw": [event.target_h, event.target_w],
+        })
+        self._next_transition_index = max(self._next_transition_index, event.transition_index + 1)
+        self._arm_stage(event.to_stage)
+
+    def on_run_end(self, event) -> None:
+        # Records and transitions are already in place; the document is
+        # assembled at node time via build_document()/to_json().
+        return None
+
+    # ------------------------------------------------------------------
+    # Measurement helpers
+    # ------------------------------------------------------------------
+    def _arm_stage(self, stage_idx: int) -> None:
+        """Set the boundary frequency + fit-prediction targets for a stage.
+
+        The current boundary (plans §27-§28) is directly measurable by this
+        stage; later boundaries are fit-extrapolation targets only (§29-§33).
+        """
+        self._omega_boundary = self._boundary_omega(stage_idx)
+        self._future_omegas = [
+            (idx, omega)
+            for idx in range(stage_idx, len(self._scales) - 1)
+            if (omega := self._boundary_omega(idx)) is not None
+        ]
+
+    def _boundary_omega(self, stage_idx: int) -> float | None:
+        """Boundary frequency of stage `stage_idx`'s next transition (§27)."""
+        if stage_idx >= len(self._scales) - 1:
+            return None  # the final stage has no next transition
+        return self._scales[stage_idx] * min(self._full_h, self._full_w) / 2.0
+
+    def _measure_x0(self, event, x0_video) -> dict[str, Any]:
+        """x0 signal basis: fit + direct boundary measurement + EMA (§24, §27-§36)."""
+        t0 = time.perf_counter() if self.record_timing else None
+        try:
+            # Plan §21: fit only the canonical range, capped at half the
+            # current stage's smaller spatial dimension, never DC.
+            omega_max = min(event.stage_h, event.stage_w) / 2.0
+            fit = fit_power_law_torch(
+                *radial_dct_power_torch(x0_video),
+                omega_min=DEFAULT_OMEGA_MIN,
+                omega_max=omega_max,
+            )
+            x0_block: dict[str, Any] = {"fit": build_fit_record(fit)}
+            boundary = self._boundary_block(event, x0_video)
+            if boundary is not None:
+                x0_block["current_boundary"] = boundary
+            x0_block["fit_predictions"] = self._fit_predictions(fit)
+            if self.store_radial_profiles:
+                freqs, profile = radial_dct_power_torch(x0_video)
+                x0_block["radial_profile"] = {
+                    "freqs": [float(v) for v in freqs.detach().cpu().tolist()],
+                    "power": [float(v) for v in profile.detach().cpu().tolist()],
+                }
+        except (ValueError, RuntimeError, ZeroDivisionError) as exc:
+            x0_block = _error_record(f"x0 measurement failed: {exc}")
+        if t0 is not None:
+            if x0_video.is_cuda:
+                torch.cuda.synchronize()
+            x0_block["analysis_ms"] = (time.perf_counter() - t0) * 1000.0
+        return x0_block
+
+    def _measure_residual(self, event, x0_video, x_video) -> dict[str, Any]:
+        """Residual basis: fit over (x - x0) (§24 B, §37)."""
+        t0 = time.perf_counter() if self.record_timing else None
+        try:
+            if x0_video.shape != x_video.shape:
+                raise ValueError(
+                    f"residual shape mismatch: x0 {list(x0_video.shape)} vs x {list(x_video.shape)}"
+                )
+            omega_max = min(event.stage_h, event.stage_w) / 2.0
+            residual = x_video.detach() - x0_video.detach()
+            freqs, profile = radial_dct_power_torch(residual)
+            del residual
+            fit = fit_power_law_torch(
+                freqs, profile,
+                omega_min=DEFAULT_OMEGA_MIN,
+                omega_max=omega_max,
+            )
+            block: dict[str, Any] = {"fit": build_fit_record(fit)}
+            # Plan §37: an independent residual-namespace boundary power +
+            # log-space EMA, directly comparable with the old static
+            # Harvester's residual basis. Never blended with the x0 EMA.
+            boundary = self._residual_boundary_block(event, freqs, profile)
+            if boundary is not None:
+                block["current_boundary"] = boundary
+        except (ValueError, RuntimeError, ZeroDivisionError) as exc:
+            block = _error_record(f"residual measurement failed: {exc}")
+        if t0 is not None:
+            if x0_video.is_cuda:
+                torch.cuda.synchronize()
+            block["analysis_ms"] = (time.perf_counter() - t0) * 1000.0
+        return block
+
+    def _residual_boundary_block(self, event, freqs, profile) -> dict[str, Any] | None:
+        """Residual-namespace boundary power + EMA (plan §37), or None when
+        the stage has no next transition or the frequency is unmeasurable."""
+        omega = self._omega_boundary
+        if omega is None or not freqs.numel():
+            return None
+        direct_available = omega <= float(freqs[-1])
+        power_point = sample_radial_power(freqs, profile, omega)
+        power_band = sample_radial_band_power(
+            freqs, profile, omega, self.boundary_band_half_width,
+        )
+        block: dict[str, Any] = {
+            "transition_index": self._next_transition_index,
+            "omega": omega,
+            "direct_available": direct_available,
+            "power_point": finite_or_none(power_point),
+            "power_band_mean": finite_or_none(power_band),
+        }
+        if direct_available and power_point > 0:
+            stage_ema = self._ema_residual.get(event.stage_index)
+            ema_power = update_log_ema(stage_ema, power_point, self.smoothing_alpha)
+            self._ema_residual[event.stage_index] = ema_power
+            block["ema_power"] = finite_or_none(ema_power)
+        else:
+            block["ema_power"] = None
+        return block
+
+    def _boundary_block(self, event, x0_video) -> dict[str, Any] | None:
+        """Direct boundary-power measurement for the stage's next transition.
+
+        Plans §27-§31 (direct point/band power + live activation thresholds
+        and eligibility) and §35 (per-stage log-space EMA of the raw x0
+        boundary power, seeded from the stage's first valid measurement —
+        never from the static A/beta). ``None`` when the stage has no next
+        transition (final stage).
+        """
+        omega = self._omega_boundary
+        if omega is None:
+            return None
+        freqs, profile = radial_dct_power_torch(x0_video)
+        direct_available = bool(freqs.numel()) and omega <= float(freqs[-1])
+        power_point = sample_radial_power(freqs, profile, omega)
+        power_band = sample_radial_band_power(
+            freqs, profile, omega, self.boundary_band_half_width,
+        )
+        block: dict[str, Any] = {
+            "transition_index": self._next_transition_index,
+            "omega": omega,
+            "direct_available": direct_available,
+            "power_point": finite_or_none(power_point),
+            "power_band_mean": finite_or_none(power_band),
+        }
+        if direct_available:
+            threshold_point = activation_threshold(power_point, self.delta)
+            threshold_band = activation_threshold(power_band, self.delta)
+            block["activation_threshold_point"] = finite_or_none(threshold_point)
+            block["activation_threshold_band"] = finite_or_none(threshold_band)
+            block["eligible_point"] = bool(event.actual_sigma <= threshold_point)
+            block["eligible_band"] = bool(event.actual_sigma <= threshold_band)
+            # Per-stage log-space EMA of the raw direct power (plan §35).
+            stage_ema = self._ema_x0.get(event.stage_index)
+            ema_power = update_log_ema(stage_ema, power_point, self.smoothing_alpha)
+            self._ema_x0[event.stage_index] = ema_power
+            ema_threshold = activation_threshold(ema_power, self.delta)
+            block["ema_power"] = finite_or_none(ema_power)
+            block["ema_threshold"] = finite_or_none(ema_threshold)
+            block["eligible_ema"] = bool(event.actual_sigma <= ema_threshold)
+        else:
+            # Plan §29: never invent a direct measurement by extrapolation.
+            block["ema_power"] = None
+            block["ema_threshold"] = None
+            block["eligible_ema"] = None
+        return block
+
+    def _fit_predictions(self, fit) -> list[dict[str, Any]]:
+        """Fit-derived boundary estimates for this and future transitions.
+
+        Plans §32-§34: the current boundary is labelled ``power_law_fit``,
+        future boundaries (beyond the current stage's representable spectrum)
+        are labelled ``fit_extrapolation`` (plan §29). Each entry carries the
+        runtime-equivalent ``predicted_original_step`` from
+        ``first_step_below(original_sigmas, threshold)``.
+        """
+        if fit["status"] != "ok" or not self._future_omegas:
+            return []
+        predictions = []
+        for transition_index, omega in self._future_omegas:
+            p_fit = power_at_frequency(omega, fit["A"], fit["beta"])
+            threshold_fit = activation_threshold(p_fit, self.delta)
+            prediction = {
+                "transition_index": transition_index,
+                "omega": omega,
+                "P": finite_or_none(p_fit),
+                "threshold": finite_or_none(threshold_fit),
+                "measurement": (
+                    "power_law_fit"
+                    if omega == self._omega_boundary
+                    else "fit_extrapolation"
+                ),
+            }
+            if self._original_sigmas:
+                prediction["predicted_original_step"] = first_step_below(
+                    self._original_sigmas, threshold_fit,
+                )
+            predictions.append(prediction)
+        return predictions
+
+    # ------------------------------------------------------------------
+    # Document assembly (plans §39, §41)
+    # ------------------------------------------------------------------
+    def set_original_sigmas(self, sigmas) -> None:
+        """Record the user's input sigma schedule (floats).
+
+        The runtime does not put the schedule on the events, so the node
+        hands it in once before the run; `predicted_original_step` and the
+        static_scheduler block read it from here.
+        """
+        values = [float(s) for s in sigmas]
+        self._original_sigmas = values
+        if self._static_scheduler:
+            self._static_scheduler["original_sigmas"] = values
+
+    def _stage_fit_series(self, stage_records, basis):
+        """Per-stage scalar fit statistics for one basis (plan §41).
+
+        Returns (beta_series, A_series, r2_series) from successfully fitted
+        records only — scalar metrics, never averaged radial profiles.
+        """
+        betas, amps, r2s = [], [], []
+        for record in stage_records:
+            fit = record.get(basis, {}).get("fit", {})
+            if fit.get("status") != "ok":
+                continue
+            betas.append(float(fit["beta"]))
+            amps.append(float(fit["A"]))
+            r2s.append(float(fit["r_squared"]))
+        return betas, amps, r2s
+
+    @staticmethod
+    def _fit_summary_block(values):
+        if not values:
+            return {"first": None, "last": None, "min": None, "max": None, "mean": None}
+        return {
+            "first": values[0],
+            "last": values[-1],
+            "min": min(values),
+            "max": max(values),
+            "mean": sum(values) / len(values),
+        }
+
+    def build_summary(self) -> dict[str, Any]:
+        """Per-stage scalar summary (plan §41). No zero-padded profile averaging."""
+        summary: dict[str, Any] = {}
+        resolved = self._static_scheduler.get("resolved_transition_steps", [])
+        scales = self._static_scheduler.get("scales", [])
+        stage_indices = sorted({r["stage_index"] for r in self.records})
+        for stage_idx in stage_indices:
+            stage_records = [r for r in self.records if r["stage_index"] == stage_idx]
+            measured = [r for r in stage_records if "x0_signal" in r or "residual" in r]
+            entry: dict[str, Any] = {
+                "stage": stage_idx,
+                "scale": scales[stage_idx] if stage_idx < len(scales) else None,
+                "measured_callbacks": len(measured),
+            }
+            has_next = stage_idx < len(scales) - 1
+            static_step = resolved[stage_idx] if has_next and stage_idx < len(resolved) else None
+            entry["static_planned_transition_step"] = static_step
+            entry["first_x0_direct_eligible_step"] = _first_eligible_step(
+                stage_records, ("x0_signal", "current_boundary", "eligible_point"),
+            )
+            entry["first_x0_ema_eligible_step"] = _first_eligible_step(
+                stage_records, ("x0_signal", "current_boundary", "eligible_ema"),
+            )
+            # Fit-eligibility: actual sigma at or below the fit-derived
+            # threshold at the current boundary frequency (plan §34).
+            entry["first_x0_fit_eligible_step"] = next(
+                (
+                    r["global_schedule_index"]
+                    for r in stage_records
+                    if _fit_threshold_at_current(r) is not None
+                    and r["sigma"]["actual"] <= _fit_threshold_at_current(r)
+                ),
+                None,
+            )
+            base = next(
+                (
+                    v
+                    for v in (
+                        entry["first_x0_direct_eligible_step"],
+                        entry["first_x0_ema_eligible_step"],
+                        entry["first_x0_fit_eligible_step"],
+                    )
+                    if v is not None
+                ),
+                None,
+            )
+            entry["difference_vs_static_step"] = (
+                base - static_step if base is not None and static_step is not None else None
+            )
+            for basis, name in (("x0_signal", "x0"), ("residual", "residual")):
+                betas, amps, r2s = self._stage_fit_series(measured, basis)
+                entry[f"{name}_beta"] = self._fit_summary_block(betas)
+                entry[f"{name}_A"] = self._fit_summary_block(amps)
+                entry[f"{name}_r2_mean"] = sum(r2s) / len(r2s) if r2s else None
+            summary[str(stage_idx)] = entry
+        return summary
+
+    def measurement_bases(self) -> list[str]:
+        bases = []
+        if self.measurement_mode != "residual_only":
+            bases.append("denoised_x0_video")
+        if self.measurement_mode != "x0_only":
+            bases.append("residual_x_minus_x0_video")
+        return bases
+
+    def build_document(self) -> dict[str, Any]:
+        """Top-level harvest document (plan §39)."""
+        return {
+            "schema_version": 1,
+            "type": "minimax_h3_speed_sigma_harvest",
+            "mode": "observational",
+            "adaptive_control": False,
+            "measurement_bases": self.measurement_bases(),
+            "sampler": "euler",
+            "static_scheduler": self._static_scheduler,
+            "analysis": self._analysis_block,
+            "records": self.records,
+            "transitions": self.transitions,
+            "summary": self.build_summary(),
+        }
+
+    def to_json(self) -> str:
+        """Strict-JSON serialization (plan §42): NaN/Infinity rejected."""
+        return dumps_strict(self.build_document())
+
+
+def _first_eligible_step(stage_records, path):
+    """First global index whose eligibility flag at `path` is True."""
+    return next(
+        (
+            r["global_schedule_index"]
+            for r in stage_records
+            if _dig(r, path) is True
+        ),
+        None,
+    )
+
+
+def _video_stream(tensor: Any) -> torch.Tensor | None:
+    """H3 NestedTensor unbind: the [B, C, T, H, W] video stream, or None.
+
+    Mirrors the extraction used by the existing diagnostic nodes — the
+    callback tensors may be a packed NestedTensor (video + audio) or a
+    plain 5-D video tensor.
+    """
+    if tensor is None:
+        return None
+    if getattr(tensor, "is_nested", False):
+        for stream in tensor.unbind():
+            if isinstance(stream, torch.Tensor) and stream.ndim == 5:
+                return stream
+        return None
+    if isinstance(tensor, torch.Tensor) and tensor.ndim == 5:
+        return tensor
+    return None
+
+
+def _error_record(reason: str) -> dict[str, Any]:
+    """Known measurement failure (plan §43): explicit error status + reason."""
+    return {"status": "error", "reason": reason}
+
+
+def _dig(record, path):
+    node: Any = record
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return None
+        node = node[key]
+    return node
+
+
+def _fit_threshold_at_current(record):
+    """The fit-derived threshold at the record's current boundary, if any."""
+    predictions = record.get("x0_signal", {}).get("fit_predictions", [])
+    for prediction in predictions:
+        if prediction.get("measurement") == "power_law_fit":
+            return prediction.get("threshold")
+    return None
+
+
 __all__ = [
     "DEFAULT_OMEGA_MIN",
     "DEFAULT_SMOOTHING_ALPHA",
+    "SpeedHarvestCollector",
     "radial_dct_power_torch",
     "fit_power_law_torch",
     "sample_radial_power",
@@ -270,3 +811,4 @@ __all__ = [
     "build_fit_record",
     "dumps_strict",
 ]
+

--- a/speed_scripts/tests/test_automatic_config.py
+++ b/speed_scripts/tests/test_automatic_config.py
@@ -1,0 +1,176 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §56 (commit 1) — flow-produced, do not hand-edit
+"""Config-equivalence and schema regression tests for the shared automatic
+SPEED config builder (speed_scripts/automatic_config.py).
+
+Plan §56: the Automatic sampler path and build_automatic_speed_config must
+produce equal SpeedConfig values from identical inputs. Plan §5/§7: the
+Automatic node's INPUT_TYPES contract must not change.
+"""
+import importlib
+
+import pytest
+import torch
+
+from conftest import install_comfy_stubs as _install_comfy_stubs
+from conftest import make_nested
+
+_install_comfy_stubs()
+
+
+def _latent(full_h=45, full_w=80):
+    """A ComfyUI LATENT dict shaped like the H3 packed AV latent."""
+    video = torch.zeros(1, 1, 2, full_h, full_w)
+    audio = torch.zeros(1, 1, 2, 44)
+    return {"samples": make_nested(video, audio)}
+
+
+def _node_config(latent, **overrides):
+    """Build a config through the Automatic sampler node's sample() path.
+
+    run_speed_pipeline is stubbed so no generation runs; the config the node
+    built is captured from the call.
+    """
+    import sampler_node as node_mod
+
+    captured = {}
+
+    def fake_pipeline(noise, guider, sigmas, latent_image, config, **kw):
+        captured["config"] = config
+        return latent_image, latent_image
+
+    node_mod = importlib.import_module("sampler_node")
+    original = node_mod.run_speed_pipeline
+    node_mod.run_speed_pipeline = fake_pipeline
+    try:
+        node = node_mod.MiniMaxH3SPEEDSampler()
+        node.sample(
+            noise=object(), guider=type("G", (), {})(), sigmas=None,
+            latent_image=latent, **overrides,
+        )
+    finally:
+        node_mod.run_speed_pipeline = original
+    return captured["config"]
+
+
+def test_input_schema_widgets_and_required_inputs():
+    """Regression: the Automatic node's required inputs and defaults are unchanged."""
+    mod = importlib.import_module("sampler_node")
+    required = mod.MiniMaxH3SPEEDSampler.INPUT_TYPES()["required"]
+    for key in ("noise", "guider", "sigmas", "latent_image", "stages"):
+        assert key in required, f"missing required input: {key}"
+    assert "preset" not in required
+    assert "transition_mode" not in required
+    assert "Tolerance (Delta)" in required or "delta" in required
+    assert "noise_amplitude" in required
+    assert "noise_decay_exponent" in required
+    assert "seed_offset" in required
+    assert required["stages"] == ("INT", {"default": 3, "min": 2, "max": 4})
+    assert required["noise_policy"] == (
+        ["direct_coarse", "coupled_full_grid"], {"default": "direct_coarse"},
+    )
+    assert required["Tolerance (Delta)"] == (
+        "FLOAT", {"default": 0.01, "min": 1e-4, "max": 0.5, "step": 0.001},
+    )
+    assert required["noise_amplitude"][1]["default"] == 7.394
+    assert required["noise_decay_exponent"][1]["default"] == 0.62
+    assert required["seed_offset"][1]["default"] == 10000
+
+
+def test_node_builds_documented_config():
+    """Plan §56: the node path must produce the documented SpeedConfig values.
+
+    The expected values are written out as literals here — not read back from
+    build_automatic_speed_config — so this test stays meaningful after the
+    node delegates to the shared helper (both sides of a node-vs-helper
+    comparison would otherwise be the same code).
+    """
+    node_cfg = _node_config(
+        _latent(45, 80),
+        stages=3,
+        noise_policy="coupled_full_grid",
+        delta=0.005,
+        noise_amplitude=12.454,
+        noise_decay_exponent=0.819,
+        seed_offset=777,
+    )
+    assert node_cfg.scales == (0.3333333333, 0.6666666667, 1.0)
+    assert node_cfg.transition_steps == (1, 2)
+    assert node_cfg.transition_mode == "delta_custom"
+    assert node_cfg.noise_policy == "coupled_full_grid"
+    assert node_cfg.delta == 0.005
+    assert node_cfg.noise_amplitude == 12.454
+    assert node_cfg.noise_decay_exponent == 0.819
+    assert node_cfg.transition_seed_offset == 777
+    assert (node_cfg.full_latent_h, node_cfg.full_latent_w) == (45, 80)
+
+
+def test_node_and_helper_build_identical_configs():
+    """Plan §56: node path vs helper path, identical inputs -> identical config."""
+    from speed_scripts.automatic_config import build_automatic_speed_config
+
+    latent = _latent(45, 80)
+    kwargs = dict(
+        stages=3,
+        noise_policy="coupled_full_grid",
+        delta=0.005,
+        noise_amplitude=12.454,
+        noise_decay_exponent=0.819,
+        seed_offset=777,
+    )
+    node_cfg = _node_config(latent, **kwargs)
+    helper_cfg = build_automatic_speed_config(latent, **kwargs)
+    for field in ("scales", "transition_steps", "transition_mode",
+                  "noise_policy", "delta", "noise_amplitude",
+                  "noise_decay_exponent", "transition_seed_offset",
+                  "full_latent_h", "full_latent_w"):
+        assert getattr(node_cfg, field) == getattr(helper_cfg, field), field
+
+
+@pytest.mark.parametrize("stages", [2, 3, 4])
+def test_scales_ladder_matches_stages(stages):
+    from speed_scripts.automatic_config import STAGES_TO_SCALES
+
+    cfg = _node_config(_latent(), stages=stages)
+    assert cfg.scales == STAGES_TO_SCALES[stages]
+    assert cfg.transition_mode == "delta_custom"
+    assert cfg.transition_steps == tuple(range(1, len(cfg.scales)))
+
+
+def test_delta_alias_order_unchanged():
+    """The Tolerance (Delta) alias chain must keep its priority order."""
+    from speed_scripts.automatic_config import build_automatic_speed_config
+
+    latent = _latent()
+    via_widget = _node_config(latent, **{"Tolerance (Delta)": 0.02})
+    assert via_widget.delta == 0.02
+    via_old = _node_config(latent, delta=0.03)
+    assert via_old.delta == 0.03
+    assert via_old.delta == build_automatic_speed_config(
+        latent, stages=3, noise_policy="direct_coarse", delta=0.03,
+        noise_amplitude=7.394, noise_decay_exponent=0.62, seed_offset=10000,
+    ).delta
+
+
+def test_full_dims_from_latent():
+    from speed_scripts.automatic_config import build_automatic_speed_config
+
+    cfg = build_automatic_speed_config(
+        _latent(45, 80), stages=2, noise_policy="direct_coarse", delta=0.01,
+        noise_amplitude=7.394, noise_decay_exponent=0.62, seed_offset=10000,
+    )
+    assert (cfg.full_latent_h, cfg.full_latent_w) == (45, 80)
+    cfg2 = build_automatic_speed_config(
+        _latent(24, 40), stages=2, noise_policy="direct_coarse", delta=0.01,
+        noise_amplitude=7.394, noise_decay_exponent=0.62, seed_offset=10000,
+    )
+    assert (cfg2.full_latent_h, cfg2.full_latent_w) == (24, 40)
+
+
+def test_preset_alias_maps_to_stages():
+    mod = importlib.import_module("sampler_node")
+    from speed_scripts.automatic_config import PRESET_TO_STAGES
+
+    assert PRESET_TO_STAGES["quarter_half_3q_full"] == 4
+    # preset kwarg still routes through the alias on the node path
+    cfg = _node_config(_latent(), preset="quarter_half_3q_full")
+    assert cfg.scales == (0.25, 0.5, 0.75, 1.0)

--- a/speed_scripts/tests/test_automatic_config.py
+++ b/speed_scripts/tests/test_automatic_config.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §56 (commit 1) — flow-produced, do not hand-edit
 """Config-equivalence and schema regression tests for the shared automatic
 SPEED config builder (speed_scripts/automatic_config.py).
 

--- a/speed_scripts/tests/test_global_transitions.py
+++ b/speed_scripts/tests/test_global_transitions.py
@@ -313,7 +313,10 @@ def test_delta_custom_duplicate_boundaries_follow_working_sigmas():
     working[1:2] and denoises ZERO steps, transition B reads the
     already-aligned coordinate, aligns it AGAIN (intentional compounding),
     patches again, and the final stage runs working[1:] with the
-    double-aligned entry.
+    double-aligned entry. The slicing and patching follow upstream SPEED;
+    one H3-runtime difference is that the zero-step intermediate stage still
+    invokes `guider.sample` once with its single-entry schedule, where
+    upstream skips the sampler for zero-step segments.
     """
     from speed_scripts.h3_runtime import resolve_transition_steps
 
@@ -436,7 +439,11 @@ def test_duplicate_transition_steps_rejected():
     zero-step intermediate segment (a single-entry sigma schedule denoises
     nothing) and still performs the spectral expand + alignment for each
     transition. Resolved ("delta_custom") steps follow that model and are
-    accepted. Explicit steps are the H3-facing convenience API, where a
+    accepted. This test only checks the config boundary, not the sampler
+    call pattern: under this H3 runtime the zero-step segment still invokes
+    `guider.sample` once (upstream skips the sampler there), while the
+    slicing and alignment above match upstream. Explicit steps are the
+    H3-facing convenience API, where a
     duplicate index cannot express a meaningful stage ladder, so it fails
     loudly at the config boundary.
     """

--- a/speed_scripts/tests/test_harvest_node.py
+++ b/speed_scripts/tests/test_harvest_node.py
@@ -94,6 +94,11 @@ def test_harvest_node_runs_native_euler_and_emits_json():
     assert "r2" in parsed
     assert "health" in parsed
     assert "report" in parsed
+    # Measurement-basis metadata (schema v2): the fit is an empirical H3
+    # residual calibration, not the SPEED paper's clean-data spectrum.
+    assert parsed["schema_version"] == 2
+    assert parsed["measurement_basis"] == "residual_x_minus_denoised"
+    assert parsed["calibration_kind"] == "empirical_h3_residual_fit"
     # The fit should be a float in a reasonable range
     assert 0.0 < float(parsed["noise_amplitude"]) < 1e6
     assert -5.0 <= float(parsed["noise_decay_exponent"]) < 10.0

--- a/speed_scripts/tests/test_online_harvest.py
+++ b/speed_scripts/tests/test_online_harvest.py
@@ -16,6 +16,7 @@ _install_comfy_stubs()
 
 from speed_scripts.harvest import fit_power_law, radial_dct_power
 from speed_scripts.online_harvest import (
+    SpeedHarvestCollector,
     build_fit_record,
     dumps_strict,
     fit_power_law_torch,
@@ -161,6 +162,33 @@ class TestDirectSampling:
         profile = torch.tensor([8.0, 4.0, 12.0])  # P(x) = 2x, scrambled order
         assert sample_radial_power(freqs, profile, 5.0) == 10.0
 
+    def test_point_sample_builds_operand_on_input_device(self, monkeypatch):
+        """The searchsorted operand is built from the input tensor
+        (``x.new_tensor``), never with an implicit CPU ``torch.tensor``."""
+        import speed_scripts.online_harvest as online_harvest
+
+        def no_implicit_cpu_tensor(*args, **kwargs):
+            raise AssertionError("implicit torch.tensor() call in sampling path")
+
+        monkeypatch.setattr(online_harvest.torch, "tensor", no_implicit_cpu_tensor)
+        freqs = torch.arange(0.0, 9.0)
+        profile = 2.0 * freqs
+        assert sample_radial_power(freqs, profile, 5.0) == 10.0
+        assert sample_radial_power(freqs, profile, 5.5) == 11.0
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="device-mismatch guard needs CUDA; runs on GPU hosts",
+    )
+    def test_point_sample_cuda_profile_stays_on_device(self):
+        """A CUDA profile must not crash searchsorted with a CPU operand."""
+        freqs = torch.arange(0.0, 9.0, device="cuda")
+        profile = 2.0 * freqs
+        assert sample_radial_power(freqs, profile, 5.5) == pytest.approx(11.0)
+        assert sample_radial_band_power(freqs, profile, 5.0, half_width=1.0) == pytest.approx(
+            (8.0 + 10.0 + 12.0) / 3.0
+        )
+
 
 class TestEmaAndJsonSafety:
     def test_ema_seeds_from_first_valid_measurement(self):
@@ -171,17 +199,36 @@ class TestEmaAndJsonSafety:
         expected = math.exp(0.75 * math.log(4.0) + 0.25 * math.log(1.0))
         assert math.isclose(ema, expected)
 
+    def test_ema_alpha_one_equals_raw_measurement(self):
+        """alpha=1.0 disables smoothing: the EMA is the raw measurement,
+        both when seeding and when a previous EMA exists."""
+        assert update_log_ema(None, 4.0, alpha=1.0) == 4.0
+        assert update_log_ema(9.0, 4.0, alpha=1.0) == 4.0
+
     def test_ema_ignores_nonpositive_raw(self):
         assert update_log_ema(4.0, 0.0) == 4.0
         assert update_log_ema(4.0, -1.0) == 4.0
 
-    def test_ema_rejects_invalid_alpha(self):
-        try:
-            update_log_ema(4.0, 1.0, alpha=0.0)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("alpha=0 must be rejected")
+    def test_ema_rejects_alpha_outside_open_closed_interval(self):
+        for alpha in (0.0, -0.5, 1.5):
+            with pytest.raises(ValueError, match="alpha"):
+                update_log_ema(4.0, 1.0, alpha=alpha)
+
+    def test_collector_accepts_full_alpha_range_and_rejects_outside(self):
+        """The collector boundary validates smoothing_alpha over (0, 1]."""
+
+        def collector(smoothing_alpha):
+            return SpeedHarvestCollector(
+                delta=0.01,
+                noise_amplitude=1.0,
+                noise_decay_exponent=1.0,
+                smoothing_alpha=smoothing_alpha,
+            )
+
+        assert collector(1.0).smoothing_alpha == 1.0
+        for alpha in (0.0, -0.5, 1.5):
+            with pytest.raises(ValueError, match="smoothing_alpha"):
+                collector(alpha)
 
     def test_finite_or_none(self):
         assert finite_or_none(1.5) == 1.5

--- a/speed_scripts/tests/test_online_harvest.py
+++ b/speed_scripts/tests/test_online_harvest.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §49 (commit 3) — flow-produced, do not hand-edit
 """Pure-math tests for the torch-native online spectral analysis (§49)."""
 
 from __future__ import annotations

--- a/speed_scripts/tests/test_online_harvest.py
+++ b/speed_scripts/tests/test_online_harvest.py
@@ -1,0 +1,223 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §49 (commit 3) — flow-produced, do not hand-edit
+"""Pure-math tests for the torch-native online spectral analysis (§49)."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from conftest import install_comfy_stubs as _install_comfy_stubs
+
+
+_install_comfy_stubs()
+
+from speed_scripts.harvest import fit_power_law, radial_dct_power
+from speed_scripts.online_harvest import (
+    build_fit_record,
+    dumps_strict,
+    fit_power_law_torch,
+    finite_or_none,
+    radial_dct_power_torch,
+    sample_radial_band_power,
+    sample_radial_power,
+    update_log_ema,
+)
+
+
+def _dct_basis_row(k: int, n: int) -> torch.Tensor:
+    """The k-th orthonormal DCT-II basis row over n samples (spectral.py convention)."""
+    x = torch.arange(n, dtype=torch.float32) + 0.5
+    row = torch.cos(math.pi / n * k * x)
+    scale = math.sqrt(1.0 / n) if k == 0 else math.sqrt(2.0 / n)
+    return row * scale
+
+
+class TestRadialPower:
+    def test_known_pure_frequency_lands_in_expected_bin(self):
+        """A video equal to one DCT basis function must put all power in that
+        function's radial frequency bin."""
+        height = width = 16
+        freq_k = 3
+        basis_2d = torch.einsum(
+            "i,j->ij", _dct_basis_row(freq_k, height), _dct_basis_row(0, width)
+        )
+        video = basis_2d[None, None, None]  # [1, 1, 1, H, W]
+
+        freqs, profile = radial_dct_power_torch(video)
+
+        assert freqs.ndim == 1 and profile.ndim == 1
+        assert freqs.numel() == profile.numel()
+        assert torch.allclose(freqs, freqs.sort().values)
+        assert torch.isfinite(profile).all()
+        assert (profile >= 0).all()
+        peak = freqs[int(profile.argmax())]
+        assert peak == freq_k
+        peak_power = float(profile.max())
+        rest = float(profile.sum()) - peak_power
+        assert peak_power > 100.0 * max(rest, 1e-12)
+
+    def test_constant_video_puts_all_power_at_dc(self):
+        video = torch.full((1, 1, 1, 8, 8), 0.25)
+        freqs, profile = radial_dct_power_torch(video)
+        assert int(freqs[0]) == 0
+        assert float(profile[0]) > 0
+        assert float(profile[1:].sum()) < 1e-6 * float(profile[0])
+
+    def test_rejects_non_video_input(self):
+        with pytest.raises(ValueError):
+            radial_dct_power_torch(torch.zeros(4, 16, 16))
+
+
+class TestTorchVsNumpy:
+    def test_random_video_matches_numpy_path(self):
+        torch.manual_seed(7)
+        video = torch.randn(2, 3, 2, 16, 24)
+
+        freqs_np, profile_np = radial_dct_power(video)
+        freqs_t, profile_t = radial_dct_power_torch(video)
+
+        common = np.intersect1d(freqs_np, freqs_t.cpu().numpy())
+        assert common.size >= 8
+        np_at = profile_np[np.searchsorted(freqs_np, common)]
+        t_at = profile_t.cpu().numpy()[np.searchsorted(freqs_t.cpu().numpy(), common)]
+        assert np.allclose(np_at, t_at, rtol=1e-4, atol=1e-7)
+
+    def test_second_call_same_resolution_uses_cache(self):
+        torch.manual_seed(11)
+        video = torch.randn(1, 1, 1, 8, 8)
+        freqs_a, profile_a = radial_dct_power_torch(video)
+        freqs_b, profile_b = radial_dct_power_torch(video * 2.0)
+        assert torch.equal(freqs_a, freqs_b)
+        assert torch.allclose(profile_b, profile_a * 4.0)
+
+
+class TestFitPowerLaw:
+    def test_known_power_law_recovered(self):
+        omega = torch.arange(1.0, 33.0)
+        profile = 12.5 * omega.pow(-1.8)
+        fit = fit_power_law_torch(omega, profile)
+        assert fit["status"] == "ok"
+        assert fit["A"] == pytest.approx(12.5)
+        assert fit["beta"] == pytest.approx(1.8)
+        assert fit["r_squared"] > 0.99999
+        assert fit["n_bins"] == 32
+        assert fit["health"] == "good"
+
+    def test_omega_max_caps_fit_range(self):
+        omega = torch.arange(1.0, 33.0)
+        profile = 12.5 * omega.pow(-1.8)
+        fit = fit_power_law_torch(omega, profile, omega_max=8.0)
+        assert fit["status"] == "ok"
+        assert fit["n_bins"] == 8
+        assert fit["A"] == pytest.approx(12.5)
+        assert fit["beta"] == pytest.approx(1.8)
+
+    def test_torch_fitter_agrees_with_numpy_fitter(self):
+        omega = torch.arange(1.0, 33.0, dtype=torch.float64)
+        jitter = 1.0 + 0.05 * torch.sin(3.0 * omega)
+        profile = 12.5 * omega.pow(-1.8) * jitter
+
+        torch_fit = fit_power_law_torch(omega, profile)
+        numpy_fit = fit_power_law(
+            omega.numpy(), profile.numpy(), omega_min=0.5
+        )
+
+        assert torch_fit["status"] == "ok"
+        for key in ("A", "beta", "r_squared"):
+            assert math.isclose(torch_fit[key], numpy_fit[key], rel_tol=1e-6)
+        assert torch_fit["n_bins"] == numpy_fit["n_bins"]
+
+
+class TestDirectSampling:
+    def test_point_sample_exact_bin_and_midpoint(self):
+        freqs = torch.arange(0.0, 9.0)
+        profile = 2.0 * freqs  # linear: P(x) = 2x
+        assert sample_radial_power(freqs, profile, 5.0) == 10.0
+        assert sample_radial_power(freqs, profile, 5.5) == 11.0
+
+    def test_point_sample_clamps_outside_range(self):
+        freqs = torch.arange(0.0, 9.0)
+        profile = 2.0 * freqs
+        assert sample_radial_power(freqs, profile, -1.0) == 0.0
+        assert sample_radial_power(freqs, profile, 100.0) == 16.0
+
+    def test_band_mean_averages_bins_in_band(self):
+        freqs = torch.arange(0.0, 9.0)
+        profile = 2.0 * freqs
+        band = sample_radial_band_power(freqs, profile, 5.0, half_width=1.0)
+        assert band == (8.0 + 10.0 + 12.0) / 3.0
+
+    def test_empty_band_falls_back_to_point_sample(self):
+        freqs = torch.arange(0.0, 9.0)
+        profile = 2.0 * freqs
+        band = sample_radial_band_power(freqs, profile, 100.0, half_width=1.0)
+        assert band == sample_radial_power(freqs, profile, 100.0)
+
+    def test_unsorted_profile_input_is_sorted_before_sampling(self):
+        freqs = torch.tensor([4.0, 2.0, 6.0])
+        profile = torch.tensor([8.0, 4.0, 12.0])  # P(x) = 2x, scrambled order
+        assert sample_radial_power(freqs, profile, 5.0) == 10.0
+
+
+class TestEmaAndJsonSafety:
+    def test_ema_seeds_from_first_valid_measurement(self):
+        assert update_log_ema(None, 4.0) == 4.0
+
+    def test_ema_log_space_update(self):
+        ema = update_log_ema(4.0, 1.0, alpha=0.25)
+        expected = math.exp(0.75 * math.log(4.0) + 0.25 * math.log(1.0))
+        assert math.isclose(ema, expected)
+
+    def test_ema_ignores_nonpositive_raw(self):
+        assert update_log_ema(4.0, 0.0) == 4.0
+        assert update_log_ema(4.0, -1.0) == 4.0
+
+    def test_ema_rejects_invalid_alpha(self):
+        try:
+            update_log_ema(4.0, 1.0, alpha=0.0)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("alpha=0 must be rejected")
+
+    def test_finite_or_none(self):
+        assert finite_or_none(1.5) == 1.5
+        assert finite_or_none(float("nan")) is None
+        assert finite_or_none(float("inf")) is None
+        assert finite_or_none(None) is None
+
+    def test_zero_profile_gives_failed_record_without_nan(self):
+        freqs = torch.arange(1.0, 17.0)
+        profile = torch.zeros(16)
+        fit = fit_power_law_torch(freqs, profile)
+        assert fit["status"] == "fit_failed"
+
+        record = build_fit_record(fit)
+        assert record == {
+            "status": "fit_failed",
+            "A": None,
+            "beta": None,
+            "r_squared": None,
+        }
+        json.dumps(record, allow_nan=False)  # must not raise
+
+    def test_nan_profile_gives_failed_record(self):
+        freqs = torch.arange(1.0, 17.0)
+        profile = torch.full((16,), float("nan"))
+        fit = fit_power_law_torch(freqs, profile)
+        assert fit["status"] == "fit_failed"
+        record = build_fit_record(fit)
+        json.dumps(record, allow_nan=False)
+
+    def test_successful_fit_record_is_strict_json_safe(self):
+        omega = torch.arange(1.0, 33.0)
+        profile = 12.5 * omega.pow(-1.8)
+        record = build_fit_record(fit_power_law_torch(omega, profile))
+        assert record["status"] == "ok"
+        assert record["A"] == pytest.approx(12.5)
+        document = {"x0_signal": {"fit": record}}
+        assert json.loads(dumps_strict(document)) == document

--- a/speed_scripts/tests/test_runtime_observer.py
+++ b/speed_scripts/tests/test_runtime_observer.py
@@ -260,7 +260,8 @@ def test_coincident_transitions_zero_step_stage():
     )
 
     # The fake guider runs the zero-step intermediate stage as a single-entry
-    # sample call: no callbacks fire inside it.
+    # sample call: no callbacks fire inside it. This is CURRENT H3-runtime
+    # behavior — upstream SPEED skips the sampler for zero-step segments.
     assert len(guider.sigma_calls) == 3
     assert len(guider.sigma_calls[1]) == 1
 

--- a/speed_scripts/tests/test_runtime_observer.py
+++ b/speed_scripts/tests/test_runtime_observer.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §50-54 (commit 2) — flow-produced, do not hand-edit
 """Runtime observer hook tests.
 
 Runs `run_speed_pipeline` with the same fake guider/noise infrastructure as

--- a/speed_scripts/tests/test_runtime_observer.py
+++ b/speed_scripts/tests/test_runtime_observer.py
@@ -1,0 +1,343 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §50-54 (commit 2) — flow-produced, do not hand-edit
+"""Runtime observer hook tests.
+
+Runs `run_speed_pipeline` with the same fake guider/noise infrastructure as
+`test_global_transitions.py` and asserts what an observer sees: one step
+event per actual denoising interval, one transition event per resolved
+transition (coincident included), actual-vs-original sigma semantics, and
+that attaching an observer leaves the generation bit-for-bit unchanged.
+"""
+
+import pytest
+import torch
+
+from conftest import install_comfy_stubs
+from speed_scripts.config import SpeedConfig
+from speed_scripts.flow import aligned_sigma
+from speed_scripts.h3_runtime import run_speed_pipeline
+from speed_scripts.observer import (
+    SpeedRunEndEvent,
+    SpeedRunStartEvent,
+    SpeedStepEvent,
+    SpeedTransitionEvent,
+)
+
+install_comfy_stubs()
+
+SIGMAS_10 = torch.tensor([1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0])
+
+FOUR_STAGE_CFG = SpeedConfig(
+    scales=(0.25, 0.5, 0.75, 1.0),
+    transition_steps=(3, 5, 8),
+    transition_mode="explicit",
+)
+
+
+class RecordingGuider:
+    """Fake guider recording every sigma schedule (same as test_global_transitions)."""
+
+    def __init__(self):
+        self.sigma_calls = []
+        self.model_patcher = type("MP", (), {"model": type("M", (), {
+            "sigma_shift_video": 12.0,
+            "sigma_shift_audio": 3.0,
+            "process_latent_out": lambda s, x: x,
+        })()})()
+        self.conds = {}
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.sigma_calls.append([float(s) for s in sigmas])
+        if callback is not None:
+            for i in range(len(sigmas) - 1):
+                callback(i, latent_image, latent_image, len(sigmas) - 1)
+        return latent_image
+
+
+class RecordingNoise:
+    """Noise that regenerates the (video, audio) streams unchanged."""
+
+    seed = 42
+
+    def generate_noise(self, latent):
+        samples = latent.get("samples")
+        if getattr(samples, "is_nested", False):
+            vids = [s for s in samples.unbind() if s.ndim == 5]
+            auds = [s for s in samples.unbind() if s.ndim != 5]
+            return type("NT", (), {"is_nested": True, "unbind": lambda self: vids + auds})()
+        return samples
+
+
+def make_latent(t=2, h=8, w=8):
+    video = torch.zeros(1, 1, t, h, w)
+    audio = torch.zeros(1, 1, 2, 44)
+    nested = type("NT", (), {"is_nested": True, "unbind": lambda self: [video, audio]})()
+    return {"samples": nested}
+
+
+class RecordingObserver:
+    """Observer that records every event and callback payload it receives."""
+
+    def __init__(self):
+        self.run_start_events = []
+        self.step_events = []
+        self.transition_events = []
+        self.run_end_events = []
+        self.step_payloads = []
+
+    def on_run_start(self, event):
+        assert isinstance(event, SpeedRunStartEvent)
+        self.run_start_events.append(event)
+
+    def on_step(self, event, x0, x):
+        assert isinstance(event, SpeedStepEvent)
+        self.step_events.append(event)
+        self.step_payloads.append((x0, x))
+
+    def on_transition(self, event):
+        assert isinstance(event, SpeedTransitionEvent)
+        self.transition_events.append(event)
+
+    def on_run_end(self, event):
+        assert isinstance(event, SpeedRunEndEvent)
+        self.run_end_events.append(event)
+
+    @property
+    def global_indices(self):
+        return [e.global_schedule_index for e in self.step_events]
+
+
+def run_pipeline(cfg, observer, sigmas=SIGMAS_10, latent=None):
+    guider = RecordingGuider()
+    out, denoised = run_speed_pipeline(
+        RecordingNoise(), guider, sigmas,
+        latent if latent is not None else make_latent(), cfg,
+        sampler=type("S", (), {"name": "euler"})(),
+        disable_pbar=True,
+        observer=observer,
+    )
+    return guider, out, denoised
+
+
+def test_step_and_transition_event_counts():
+    """§50: 4-stage (3,5,8) on 11 sigmas -> 10 step events, 3 transitions.
+
+    Global denoising indices 0..2, 3..4, 5..7, 8..9; each exactly once.
+    """
+    observer = RecordingObserver()
+    run_pipeline(FOUR_STAGE_CFG, observer)
+
+    assert observer.global_indices == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert len(observer.transition_events) == 3
+    assert len(observer.run_start_events) == 1
+    assert len(observer.run_end_events) == 1
+    assert len(observer.step_payloads) == 10
+
+    start = observer.run_start_events[0]
+    assert start.n_stages == 4
+    assert start.scales == (0.25, 0.5, 0.75, 1.0)
+    assert start.transition_steps == (3, 5, 8)
+    assert start.global_steps == 10
+
+    end = observer.run_end_events[0]
+    assert end.n_stages == 4
+    assert end.global_steps == 10
+    assert end.transition_count == 3
+
+
+def test_stage_metadata_mapping():
+    """§51: callback global indices map to stages 0..3 with no skips/dupes."""
+    observer = RecordingObserver()
+    run_pipeline(FOUR_STAGE_CFG, observer)
+
+    # Stage k owns global denoising indices [boundary_{k-1} .. boundary_k - 1]
+    # (stage 0 starts at 0; the final stage runs to the schedule end).
+    boundaries = (3, 5, 8)
+    stage_starts = (0,) + boundaries
+    for event in observer.step_events:
+        expected_stage = max(
+            i for i, start in enumerate(stage_starts) if event.global_schedule_index >= start
+        )
+        assert event.stage_index == expected_stage, (
+            f"global {event.global_schedule_index} ran in stage {event.stage_index}, "
+            f"expected {expected_stage}"
+        )
+        assert event.stage_local_step == event.global_schedule_index - stage_starts[expected_stage]
+
+    # No skipped or duplicated denoising index.
+    indices = observer.global_indices
+    assert indices == sorted(set(indices)) == list(range(10))
+
+    # Stage scales and geometry come from the actual stage slice.
+    scales = (0.25, 0.5, 0.75, 1.0)
+    stage_counts = {0: 3, 1: 2, 2: 3, 3: 2}
+    for event in observer.step_events:
+        assert event.stage_scale == scales[event.stage_index]
+        assert (event.stage_h, event.stage_w) == (
+            round(8 * scales[event.stage_index]), round(8 * scales[event.stage_index]),
+        )
+        assert event.full_h == 8 and event.full_w == 8 and event.full_t == 2
+    for stage_idx, count in stage_counts.items():
+        assert sum(1 for e in observer.step_events if e.stage_index == stage_idx) == count
+
+    # Transition events line up with the resolved boundaries.
+    transitions = observer.transition_events
+    assert [(t.from_stage, t.to_stage) for t in transitions] == [(0, 1), (1, 2), (2, 3)]
+    assert [t.global_schedule_index for t in transitions] == [3, 5, 8]
+    assert [t.transition_index for t in transitions] == [0, 1, 2]
+    assert [t.from_scale for t in transitions] == [0.25, 0.5, 0.75]
+    assert [t.to_scale for t in transitions] == [0.5, 0.75, 1.0]
+    for t in transitions:
+        assert t.scale_ratio == pytest.approx(t.to_scale / t.from_scale)
+        assert t.source_h < t.target_h and t.source_w < t.target_w
+
+
+def test_actual_vs_original_sigma_at_boundaries():
+    """§52: after each transition actual_sigma is the aligned (patched) working
+    sigma; original_sigma is the untouched input schedule entry. They differ
+    exactly by the kappa alignment."""
+    observer = RecordingObserver()
+    run_pipeline(FOUR_STAGE_CFG, observer)
+
+    orig = [float(s) for s in SIGMAS_10]
+    scales = (0.25, 0.5, 0.75, 1.0)
+    boundaries = (3, 5, 8)
+
+    # First callback of each post-transition stage sits at its boundary.
+    first_after = {}
+    for event in observer.step_events:
+        if event.global_schedule_index in boundaries and event.global_schedule_index not in first_after:
+            first_after[event.global_schedule_index] = event
+    assert set(first_after) == set(boundaries)
+
+    for boundary_idx, boundary in enumerate(boundaries):
+        event = first_after[boundary]
+        ratio = scales[boundary_idx + 1] / scales[boundary_idx]
+        kappa, aligned = aligned_sigma(orig[boundary], ratio)
+
+        assert event.actual_sigma == pytest.approx(aligned), (
+            f"actual_sigma at boundary {boundary} must be the patched working sigma"
+        )
+        assert event.original_sigma == pytest.approx(orig[boundary])
+        assert event.original_sigma_next == pytest.approx(orig[boundary + 1])
+        assert event.actual_sigma != pytest.approx(event.original_sigma), (
+            "kappa alignment must move the boundary sigma for this schedule"
+        )
+
+        # The transition event agrees: before/after alignment straddle it.
+        transition = observer.transition_events[boundary_idx]
+        assert transition.global_schedule_index == boundary
+        assert transition.sigma_before_alignment == pytest.approx(orig[boundary])
+        assert transition.sigma_after_alignment == pytest.approx(aligned)
+        assert transition.kappa == pytest.approx(kappa)
+
+    # Interior callbacks of the untouched first stage carry schedule values.
+    for event in observer.step_events:
+        if event.stage_index == 0:
+            assert event.actual_sigma == pytest.approx(event.original_sigma)
+            assert event.actual_sigma_next == pytest.approx(event.original_sigma_next)
+
+
+def test_coincident_transitions_zero_step_stage():
+    """§53: delta_custom resolving to (1,1) on the 8x8 latent calibration.
+
+    Stage 0 steps -> transition A -> NO step in the zero-step intermediate
+    stage -> transition B (whose before-alignment value is what transition A
+    patched) -> final stage callbacks.
+    """
+    sigmas = torch.linspace(1.0, 0.0, 11)
+    cfg = SpeedConfig(
+        scales=(0.25, 0.5, 1.0),
+        transition_steps=(3, 5),  # ignored by delta_custom
+        transition_mode="delta_custom",
+        delta=0.01,
+        noise_amplitude=219.48,
+        noise_decay_exponent=2.42,
+        full_latent_h=8,
+        full_latent_w=8,
+    )
+    observer = RecordingObserver()
+    guider, _out, _denoised = run_pipeline(
+        cfg, observer, sigmas=sigmas, latent=make_latent(t=2, h=8, w=8),
+    )
+
+    # The fake guider runs the zero-step intermediate stage as a single-entry
+    # sample call: no callbacks fire inside it.
+    assert len(guider.sigma_calls) == 3
+    assert len(guider.sigma_calls[1]) == 1
+
+    # Stage 0: global 0 only (boundary 1); final stage: global 1..9.
+    assert observer.global_indices == [0] + list(range(1, 10))
+    assert observer.step_events[0].stage_index == 0
+    assert all(e.stage_index == 2 for e in observer.step_events[1:])
+    assert not [e for e in observer.step_events if e.stage_index == 1]
+
+    # Exactly two transition events, both at the coincident boundary.
+    transitions = observer.transition_events
+    assert len(transitions) == 2
+    assert all(t.global_schedule_index == 1 for t in transitions)
+    assert [(t.from_stage, t.to_stage) for t in transitions] == [(0, 1), (1, 2)]
+
+    # Transition B reads the coordinate transition A patched.
+    orig = [float(s) for s in sigmas]
+    ratio_a = 0.5 / 0.25
+    ratio_b = 1.0 / 0.5
+    _kappa_a, new_q_a = aligned_sigma(orig[1], ratio_a)
+    _kappa_b, new_q_b = aligned_sigma(new_q_a, ratio_b)
+
+    assert transitions[0].sigma_before_alignment == pytest.approx(orig[1])
+    assert transitions[0].sigma_after_alignment == pytest.approx(new_q_a)
+    assert transitions[1].sigma_before_alignment == pytest.approx(new_q_a), (
+        "transition B must read transition A's patched boundary value"
+    )
+    assert transitions[1].sigma_after_alignment == pytest.approx(new_q_b)
+    assert transitions[1].sigma_after_alignment != pytest.approx(transitions[1].sigma_before_alignment)
+
+    # The final stage re-enters at the double-aligned coordinate.
+    assert observer.step_events[1].actual_sigma == pytest.approx(new_q_b)
+    assert observer.step_events[1].original_sigma == pytest.approx(orig[1])
+
+
+def test_observer_is_behaviorally_inert():
+    """§54: the same deterministic fake generation with observer=None vs a
+    RecordingObserver -> identical outputs, identical denoised, identical
+    guider sigma calls, identical transition schedule."""
+
+    def run(observer):
+        guider = RecordingGuider()
+        out, denoised = run_speed_pipeline(
+            RecordingNoise(), guider, SIGMAS_10, make_latent(), FOUR_STAGE_CFG,
+            sampler=type("S", (), {"name": "euler"})(),
+            disable_pbar=True,
+            observer=observer,
+        )
+        return guider, out, denoised
+
+    guider_none, out_none, denoised_none = run(None)
+    observer = RecordingObserver()
+    guider_obs, out_obs, denoised_obs = run(observer)
+
+    samples_none = list(out_none["samples"].unbind())
+    samples_obs = list(out_obs["samples"].unbind())
+    assert torch.equal(samples_none[0], samples_obs[0])
+    assert torch.equal(samples_none[1], samples_obs[1])
+    assert torch.equal(denoised_none["samples"], denoised_obs["samples"])
+    assert guider_none.sigma_calls == guider_obs.sigma_calls
+
+    # Transition schedule identical: 4 stage calls, canonical global slices,
+    # total denoising steps == len(sigmas) - 1.
+    orig = [float(s) for s in SIGMAS_10]
+    assert len(guider_obs.sigma_calls) == 4
+    assert guider_obs.sigma_calls[0] == orig[0:4]
+    total_steps = sum(len(call) - 1 for call in guider_obs.sigma_calls)
+    assert total_steps == len(SIGMAS_10) - 1
+
+    # The observing run saw the full event stream.
+    assert observer.global_indices == list(range(10))
+    assert len(observer.transition_events) == 3
+
+
+def test_step_event_callback_indices_are_global():
+    """callback_index counts denoising intervals across the whole run."""
+    observer = RecordingObserver()
+    run_pipeline(FOUR_STAGE_CFG, observer)
+    assert [e.callback_index for e in observer.step_events] == list(range(10))

--- a/speed_scripts/tests/test_speed_sigma_harvest_node.py
+++ b/speed_scripts/tests/test_speed_sigma_harvest_node.py
@@ -1,0 +1,459 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §55-56 (commit 4) — flow-produced, do not hand-edit
+"""Node tests for the continuous SPEED Sigma Harvest (plan §55, §56).
+
+Drives `run_speed_pipeline` through the node with the same fake
+guider/noise infrastructure as the commit-2 observer tests: one SPEED
+generation (no native pre-pass, no second run), three outputs, per-callback
+records at stride 1, both measurement bases, strict-JSON output, and
+Automatic-vs-harvest config equivalence.
+
+The node builds its SpeedConfig through the shared automatic builder
+(delta_custom), so expected stage boundaries are computed here from the
+runtime's own public scheduling math (`power_at_frequency`,
+`activation_threshold`, `first_step_below`) instead of hardcoding indices.
+"""
+
+import importlib
+import importlib.util
+import json
+import math
+
+import pytest
+import torch
+
+from conftest import install_comfy_stubs as _install_comfy_stubs
+
+_install_comfy_stubs()
+
+import speed_scripts.h3_runtime as h3_runtime
+
+SIGMAS_10 = torch.tensor([1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0])
+
+DEFAULTS = dict(delta=0.01, noise_amplitude=7.394, noise_decay_exponent=0.62)
+
+
+class SpectralGuider:
+    """Fake guider whose x0 payload carries deterministic spectral content.
+
+    sample() echoes the latent and fires one callback per denoising
+    interval with a non-zero pattern x0 (so the radial DCT fits have real
+    bins) and the raw state as x — the shapes the runtime's
+    `_wrap_observer_callback` hands to an observer.
+    """
+
+    def __init__(self):
+        self.sigma_calls = []
+        self.model_patcher = type("MP", (), {"model": type("M", (), {
+            "sigma_shift_video": 12.0,
+            "sigma_shift_audio": 3.0,
+            "process_latent_out": lambda s, x: x,
+        })()})()
+        self.conds = {}
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.sigma_calls.append([float(s) for s in sigmas])
+        if callback is not None:
+            n_steps = len(sigmas) - 1
+            for i in range(n_steps):
+                progress = (i + 1) / n_steps
+                streams = []
+                for stream in latent_image.unbind():
+                    # Deterministic non-trivial pattern: a seeded random
+                    # field has a dense DCT spectrum, so every radial bin
+                    # is positive and the fits succeed at any resolution.
+                    generator = torch.Generator().manual_seed(1234)
+                    pattern = torch.rand(stream.shape, generator=generator) * 2.0 - 1.0
+                    streams.append(pattern * progress)
+                x0 = type("NT", (), {
+                    "is_nested": True,
+                    "unbind": lambda self, _s=streams: list(_s),
+                })()
+                callback(i, x0, latent_image, n_steps)
+        return latent_image
+
+
+class EchoNoise:
+    """Noise that regenerates the (video, audio) streams unchanged."""
+
+    seed = 42
+
+    def generate_noise(self, latent):
+        samples = latent.get("samples")
+        vids = [s for s in samples.unbind() if s.ndim == 5]
+        auds = [s for s in samples.unbind() if s.ndim != 5]
+        return type("NT", (), {"is_nested": True, "unbind": lambda self: vids + auds})()
+
+
+def make_latent(t=2, h=8, w=8, **extra):
+    video = torch.zeros(1, 1, t, h, w)
+    audio = torch.zeros(1, 1, 2, 44)
+    nested = type("NT", (), {"is_nested": True, "unbind": lambda self: [video, audio]})()
+    latent = {"samples": nested}
+    latent.update(extra)
+    return latent
+
+
+def expected_boundaries(sigmas, full_h, full_w, scales, delta, A, beta):
+    """Resolve delta_custom boundaries with the runtime's own public math."""
+    boundaries = []
+    for scale in scales[:-1]:
+        omega = scale * min(full_h, full_w) / 2.0
+        p = h3_runtime.power_at_frequency(omega, A, beta)
+        threshold = h3_runtime.activation_threshold(p, delta)
+        boundaries.append(h3_runtime._find_first_step_below(sigmas, threshold))
+    return tuple(boundaries)
+
+
+def _expected(sigmas, full_h, full_w, scales=(0.25, 0.5, 0.75, 1.0)):
+    return expected_boundaries(
+        sigmas, full_h, full_w, scales,
+        delta=DEFAULTS["delta"],
+        A=DEFAULTS["noise_amplitude"],
+        beta=DEFAULTS["noise_decay_exponent"],
+    )
+
+
+def _run_node(sigmas=SIGMAS_10, latent=None, measurement_mode="both",
+              analysis_stride=1, **overrides):
+    """Run the harvest node's sample() and return (document, info).
+
+    run_speed_pipeline is forwarded to the real implementation (the node
+    must drive the actual pipeline); call counting happens via the guider's
+    sigma_calls.
+    """
+    mod = importlib.import_module("sampler_speed_sigma_harvest_node")
+    node = mod.MiniMaxH3SPEEDSigmaHarvest()
+    guider = SpectralGuider()
+    latent = latent if latent is not None else make_latent()
+    kwargs = dict(DEFAULTS)
+    kwargs.update(overrides)
+    result = node.sample(
+        noise=EchoNoise(),
+        guider=guider,
+        sigmas=sigmas,
+        latent_image=latent,
+        stages=4,
+        noise_policy="direct_coarse",
+        measurement_mode=measurement_mode,
+        analysis_stride=analysis_stride,
+        **kwargs,
+    )
+    json_text, output, denoised = result
+    return json.loads(json_text), {
+        "output": output,
+        "denoised": denoised,
+        "guider": guider,
+        "latent": latent,
+        "module": mod,
+    }
+
+
+def test_node_schema_and_registration():
+    """§48/§55: registration mapping, three named outputs, generation
+    inputs identical to the Automatic sampler."""
+    mod = importlib.import_module("sampler_speed_sigma_harvest_node")
+    cls = mod.MiniMaxH3SPEEDSigmaHarvest
+    assert cls.RETURN_TYPES == ("STRING", "LATENT", "LATENT")
+    assert cls.RETURN_NAMES == ("harvest_json", "output", "denoised_output")
+    assert cls.CATEGORY == "sampling/minimax_h3_speed/diagnostics"
+    assert "MiniMaxH3SPEEDSigmaHarvest" in mod.NODE_CLASS_MAPPINGS
+
+    # §48: the pack's registration loop picks the node up. Import the
+    # package directory as a module by path (its name is not importable
+    # as a plain identifier).
+    from pathlib import Path
+
+    pack_path = Path(__file__).resolve().parents[2] / "__init__.py"
+    spec = importlib.util.spec_from_file_location("pack_init", pack_path)
+    pack = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pack)
+    assert "sampler_speed_sigma_harvest_node" in pack._NODE_MODULES
+    aggregated = {}
+    for name in pack._NODE_MODULES:
+        node_mod = importlib.import_module(name)
+        aggregated.update(getattr(node_mod, "NODE_CLASS_MAPPINGS", {}))
+    assert "MiniMaxH3SPEEDSigmaHarvest" in aggregated
+
+    required = cls.INPUT_TYPES()["required"]
+    for key in ("noise", "guider", "sigmas", "latent_image", "stages",
+                "noise_policy", "Tolerance (Delta)", "noise_amplitude",
+                "noise_decay_exponent", "seed_offset", "measurement_mode",
+                "analysis_stride", "smoothing_alpha",
+                "boundary_band_half_width", "store_radial_profiles"):
+        assert key in required, f"missing required input: {key}"
+    auto_required = importlib.import_module(
+        "sampler_node"
+    ).MiniMaxH3SPEEDSampler.INPUT_TYPES()["required"]
+    for key, spec in auto_required.items():
+        assert required[key] == spec, f"generation input {key} drifted from the Automatic sampler"
+
+
+def test_single_speed_pass_three_outputs_metadata_preserved():
+    """§55: exactly one SPEED generation (four stage guider.sample calls,
+    no native pre-pass); outputs flow from that run and keep latent
+    metadata."""
+    latent = make_latent(metadata="keep", extra_key=[1, 2, 3])
+    document, info = _run_node(latent=latent)
+
+    assert len(info["guider"].sigma_calls) == 4
+    assert document["records"], "no telemetry collected"
+
+    assert info["output"] is not latent
+    assert info["output"]["metadata"] == "keep"
+    assert info["output"]["extra_key"] == [1, 2, 3]
+    assert info["denoised"] is not latent
+    assert info["denoised"]["metadata"] == "keep"
+    assert info["denoised"]["extra_key"] == [1, 2, 3]
+
+
+def test_records_every_callback_with_stage_metadata():
+    """§55: stride=1 records every denoising interval; stage metadata and
+    transition events match the delta_custom resolution the Automatic
+    config produces for this latent."""
+    latent = make_latent(t=2, h=72, w=80)
+    document, info = _run_node(latent=latent)
+
+    records = document["records"]
+    assert [r["callback_index"] for r in records] == list(range(10))
+    assert [r["global_schedule_index"] for r in records] == list(range(10))
+
+    boundaries = _expected(SIGMAS_10, 72, 80)
+    scales = (0.25, 0.5, 0.75, 1.0)
+    stage_starts = (0,) + boundaries
+    for record in records:
+        expected_stage = max(
+            i for i, start in enumerate(stage_starts)
+            if record["global_schedule_index"] >= start
+        )
+        assert record["stage_index"] == expected_stage
+        assert record["stage_scale"] == scales[expected_stage]
+
+    transitions = document["transitions"]
+    assert [t["transition_index"] for t in transitions] == [0, 1, 2]
+    assert [t["global_schedule_index"] for t in transitions] == list(boundaries)
+
+
+def test_both_bases_and_mode_respected():
+    """§55: mode=both records both bases; x0_only omits the residual key;
+    residual_only omits the x0 fit. Uses a full-size latent so the radial
+    fits have enough bins to succeed (plan §21: at least 3 non-DC bins)."""
+    latent = make_latent(t=2, h=72, w=80)
+    document, _ = _run_node(latent=latent)
+    record = document["records"][0]
+    assert record["x0_signal"]["fit"]["status"] == "ok"
+    assert record["residual"]["fit"]["status"] == "ok"
+    assert document["measurement_bases"] == [
+        "denoised_x0_video", "residual_x_minus_x0_video",
+    ]
+
+    x0_only, _ = _run_node(latent=latent, measurement_mode="x0_only")
+    x0_record = x0_only["records"][0]
+    assert "x0_signal" in x0_record
+    assert "residual" not in x0_record
+    assert x0_only["measurement_bases"] == ["denoised_x0_video"]
+
+    residual_only, _ = _run_node(latent=latent, measurement_mode="residual_only")
+    res_record = residual_only["records"][0]
+    assert "residual" in res_record
+    assert "x0_signal" not in res_record
+    assert residual_only["measurement_bases"] == ["residual_x_minus_x0_video"]
+
+
+def test_tiny_latent_fit_fails_explicitly():
+    """§21/§43: a 2x2 coarse stage has a single non-DC radial bin, below
+    the 3-bin minimum, so the fit fails explicitly — a JSON-safe
+    fit_failed record with null numerics, not NaN and not a crash."""
+    document, _ = _run_node()
+    record = document["records"][0]
+    fit = record["x0_signal"]["fit"]
+    assert fit["status"] == "fit_failed"
+    assert fit["A"] is None and fit["beta"] is None and fit["r_squared"] is None
+    # The boundary block still records direct power (measurable with bins),
+    # and the run completes with strict JSON.
+    json.dumps(document, allow_nan=False)
+
+
+def test_boundary_and_fit_predictions_present():
+    """§27-§34: the boundary block carries direct power, thresholds,
+    eligibility and the EMA; fit predictions label current vs extrapolated."""
+    latent = make_latent(t=2, h=72, w=80)
+    document, _ = _run_node(latent=latent)
+
+    stage0 = next(
+        r for r in document["records"] if r["stage_index"] == 0
+    )["x0_signal"]
+    boundary = stage0["current_boundary"]
+    assert boundary["direct_available"] is True
+    assert boundary["omega"] == pytest.approx(0.25 * 72 / 2)
+    assert boundary["power_point"] > 0
+    assert boundary["power_band_mean"] > 0
+    assert 0.0 < boundary["activation_threshold_point"] < 1.0
+    assert isinstance(boundary["eligible_point"], bool)
+    assert boundary["ema_power"] > 0
+    assert 0.0 < boundary["ema_threshold"] < 1.0
+
+    predictions = stage0["fit_predictions"]
+    assert predictions, "fit predictions missing"
+    labels = [p["measurement"] for p in predictions]
+    assert "power_law_fit" in labels
+    assert "fit_extrapolation" in labels
+    for p in predictions:
+        assert isinstance(p["predicted_original_step"], int)
+
+    # Final-stage records have no current boundary (no next transition).
+    final_records = [r for r in document["records"] if r["stage_index"] == 3]
+    assert final_records
+    for r in final_records:
+        assert "current_boundary" not in r["x0_signal"]
+
+
+def test_coincident_transition_zero_step_stages_recorded():
+    """§16/§53 through the node: at 8x8 the automatic calibration resolves
+    to coincident boundaries [1, 1, 1]; the zero-step intermediate stages
+    emit no records, both transitions still fire, and the final stage
+    carries the remaining callbacks."""
+    document, _ = _run_node()
+
+    boundaries = _expected(SIGMAS_10, 8, 8)
+    # The 8x8 calibration really does quantize to a coincident boundary,
+    # otherwise this test would not exercise the zero-step path.
+    assert len(set(boundaries)) < len(boundaries)
+
+    transitions = document["transitions"]
+    assert [t["global_schedule_index"] for t in transitions] == list(boundaries)
+    assert [(t["from_stage"], t["to_stage"]) for t in transitions] == [(0, 1), (1, 2), (2, 3)]
+
+    stage_indices = {r["stage_index"] for r in document["records"]}
+    zero_step_stages = {
+        t["to_stage"] for t in transitions
+        if t["to_stage"] not in stage_indices
+    }
+    assert zero_step_stages, "expected at least one zero-step intermediate stage"
+
+
+def test_strict_json_no_nan():
+    """§55: the document round-trips a strict parser; no NaN anywhere."""
+    document, _ = _run_node(measurement_mode="both", analysis_stride=1)
+    text = json.dumps(document, allow_nan=False)  # must not raise
+    reparsed = json.loads(text, parse_constant=_reject_constant)
+    _no_nan(reparsed)
+
+
+def _reject_constant(value):
+    raise AssertionError(f"non-JSON constant in document: {value}")
+
+
+def _no_nan(value):
+    if isinstance(value, float):
+        assert math.isfinite(value)
+    elif isinstance(value, dict):
+        for v in value.values():
+            _no_nan(v)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            _no_nan(v)
+
+
+def test_ema_seeded_from_first_measurement_not_calibration():
+    """§36: the stage's first EMA value equals its first raw measurement —
+    never a power derived from the static A/beta."""
+    document, _ = _run_node()
+    stage_records = [r for r in document["records"] if r["stage_index"] == 0]
+    first = stage_records[0]["x0_signal"]["current_boundary"]
+    assert first["ema_power"] == pytest.approx(first["power_point"])
+
+
+def test_stride_respects_analysis_stride():
+    """§25: stride=2 analyses every second callback; unmeasured callbacks
+    still get skeleton records."""
+    document, _ = _run_node(analysis_stride=2)
+
+    records = document["records"]
+    assert len(records) == 10
+    measured = [r for r in records if "x0_signal" in r]
+    assert [r["callback_index"] for r in measured] == [0, 2, 4, 6, 8]
+    skeleton = next(r for r in records if r["callback_index"] == 1)
+    assert "x0_signal" not in skeleton and "residual" not in skeleton
+
+
+def test_summary_is_scalar_per_stage():
+    """§41: per-stage summary blocks exist with scalar fit statistics."""
+    latent = make_latent(t=2, h=72, w=80)
+    document, _ = _run_node(latent=latent)
+
+    summary = document["summary"]
+    assert "0" in summary
+    stage0 = summary["0"]
+    boundaries = _expected(SIGMAS_10, 72, 80)
+    assert stage0["static_planned_transition_step"] == boundaries[0]
+    for name in ("x0_beta", "x0_A", "residual_beta", "residual_A"):
+        block = stage0[name]
+        assert block["first"] is not None
+        assert block["min"] <= block["mean"] <= block["max"]
+    assert stage0["x0_r2_mean"] is not None
+
+
+def test_top_level_schema_fields():
+    """§39: schema_version, mode, measurement_bases, static_scheduler,
+    analysis block."""
+    document, _ = _run_node()
+
+    assert document["schema_version"] == 1
+    assert document["type"] == "minimax_h3_speed_sigma_harvest"
+    assert document["mode"] == "observational"
+    assert document["adaptive_control"] is False
+    assert document["sampler"] == "euler"
+    assert document["measurement_bases"] == [
+        "denoised_x0_video", "residual_x_minus_x0_video",
+    ]
+    scheduler = document["static_scheduler"]
+    assert scheduler["stages"] == 4
+    assert scheduler["scales"] == [0.25, 0.5, 0.75, 1.0]
+    assert scheduler["resolved_transition_steps"] == list(_expected(SIGMAS_10, 8, 8))
+    assert scheduler["original_sigmas"] == SIGMAS_10.tolist()
+    assert scheduler["delta"] == 0.01
+    assert document["analysis"]["stride"] == 1
+    assert document["analysis"]["measurement_mode"] == "both"
+
+
+def test_automatic_vs_harvest_config_equivalence():
+    """§56: identical inputs -> equal SpeedConfig fields on both node paths."""
+    from speed_scripts.tests.test_automatic_config import _latent, _node_config
+
+    kwargs = dict(
+        stages=3,
+        noise_policy="coupled_full_grid",
+        delta=0.005,
+        noise_amplitude=12.454,
+        noise_decay_exponent=0.819,
+        seed_offset=777,
+    )
+    auto_cfg = _node_config(_latent(45, 80), **kwargs)
+
+    captured = {}
+
+    def spy(noise, guider, sigmas, latent_image, config, **kw):
+        captured["config"] = config
+        return latent_image, latent_image
+
+    mod = importlib.import_module("sampler_speed_sigma_harvest_node")
+    original = mod.run_speed_pipeline
+    mod.run_speed_pipeline = spy
+    try:
+        node = mod.MiniMaxH3SPEEDSigmaHarvest()
+        node.sample(
+            noise=EchoNoise(),
+            guider=SpectralGuider(),
+            sigmas=SIGMAS_10,
+            latent_image=_latent(45, 80),
+            **kwargs,
+        )
+    finally:
+        mod.run_speed_pipeline = original
+
+    harvest_cfg = captured["config"]
+    for field in ("scales", "transition_steps", "transition_mode",
+                  "noise_policy", "delta", "noise_amplitude",
+                  "noise_decay_exponent", "transition_seed_offset",
+                  "full_latent_h", "full_latent_w"):
+        assert getattr(auto_cfg, field) == getattr(harvest_cfg, field), field

--- a/speed_scripts/tests/test_speed_sigma_harvest_node.py
+++ b/speed_scripts/tests/test_speed_sigma_harvest_node.py
@@ -362,6 +362,48 @@ def test_ema_seeded_from_first_measurement_not_calibration():
     assert first["ema_power"] == pytest.approx(first["power_point"])
 
 
+def test_alpha_one_records_raw_boundary_power_as_ema():
+    """§35 with the full widget range: smoothing_alpha=1.0 disables
+    smoothing, so every recorded EMA power equals the raw boundary power
+    of the same step."""
+    document, _ = _run_node(measurement_mode="x0_only", smoothing_alpha=1.0)
+
+    boundaries = [
+        r["x0_signal"]["current_boundary"]
+        for r in document["records"]
+        if r.get("x0_signal", {}).get("current_boundary") is not None
+    ]
+    assert boundaries, "no boundary measurements recorded"
+    for boundary in boundaries:
+        assert boundary["ema_power"] == pytest.approx(boundary["power_point"])
+        assert boundary["eligible_ema"] == boundary["eligible_point"]
+
+
+def test_single_dct_per_measured_callback(monkeypatch):
+    """Exactly one radial_dct_power_torch call per measured x0 callback,
+    whether or not radial profiles are stored (x0_only isolates the x0
+    path; the residual basis adds its own single call per callback)."""
+    import speed_scripts.online_harvest as online_harvest
+
+    calls = {"count": 0}
+    original = online_harvest.radial_dct_power_torch
+
+    def counting(video):
+        calls["count"] += 1
+        return original(video)
+
+    monkeypatch.setattr(online_harvest, "radial_dct_power_torch", counting)
+    document, _ = _run_node(
+        latent=make_latent(t=2, h=72, w=80),
+        measurement_mode="x0_only",
+        store_radial_profiles=True,
+    )
+
+    measured = [r for r in document["records"] if "x0_signal" in r]
+    assert len(measured) == 10
+    assert calls["count"] == 10
+
+
 def test_stride_respects_analysis_stride():
     """§25: stride=2 analyses every second callback; unmeasured callbacks
     still get skeleton records."""

--- a/speed_scripts/tests/test_speed_sigma_harvest_node.py
+++ b/speed_scripts/tests/test_speed_sigma_harvest_node.py
@@ -1,4 +1,3 @@
-# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §55-56 (commit 4) — flow-produced, do not hand-edit
 """Node tests for the continuous SPEED Sigma Harvest (plan §55, §56).
 
 Drives `run_speed_pipeline` through the node with the same fake


### PR DESCRIPTION
# feat: Continuous SPEED Sigma Harvester (observational per-step spectral telemetry)

## What this changes

This adds a new diagnostic node, `MiniMax H3 SPEED — SPEED Sigma Harvest (Continuous)` (`nodes/sampler_speed_sigma_harvest_node.py`). It runs one normal multi-stage SPEED generation and records the model's spectral state at every denoising step. The node is observational only: it never moves stage transitions, changes noise, or touches seeds. The generation it measures is bit-for-bit the generation a plain Automatic SPEED run would produce.

Two kinds of spectra are recorded at every step, under separate JSON namespaces: the `x0_signal` spectrum (the model's denoised prediction — the clean-data power `P_omega` from the SPEED paper's activation equation) and the `residual` spectrum (`x - x0` — the same basis the existing native Sigma Harvest calibrates on). Per step the node reports the fitted power law (`A`, `beta`, `r_squared`), a direct power measurement at the frequency of the stage's next transition, live activation thresholds with eligibility flags, and a per-stage smoothed (EMA) boundary power for later study.

## Why this change exists

The pack could calibrate SPEED only before a run: the native Sigma Harvest does one full-resolution Euler pass and produces one static `A / beta` pair. There was no way to see whether that calibration actually holds while a real multi-stage SPEED generation is running. This feature builds the measurement path so that question becomes answerable from data, before anyone considers letting live measurements control transitions (which would require a larger runtime rewrite and is deliberately not attempted here).

## Where and how the code runs

In a ComfyUI graph, the new node takes the same generation inputs as the Automatic sampler (`noise`, `guider`, `sigmas`, `latent_image`, plus stage and calibration widgets) and a small diagnostic block (`measurement_mode`, `analysis_stride`, `smoothing_alpha`, `boundary_band_half_width`, `store_radial_profiles`). When executed:

1. Both the Automatic sampler and the new node build their `SpeedConfig` through one shared helper, `build_automatic_speed_config` in `speed_scripts/automatic_config.py`, so the two nodes cannot drift apart.
2. The node hands a `SpeedHarvestCollector` (`speed_scripts/online_harvest.py`) to `run_speed_pipeline` as an optional `observer` (`speed_scripts/observer.py`). The runtime emits one event per real denoising step, one per resolution transition (coincident transitions included), and run start/end markers. With `observer=None` (the default) the runtime behaves exactly as before — this is proven by a dedicated equivalence test.
3. The collector reduces each step's video tensors on the GPU to scalars and small lists (torch-native radial DCT power, power-law fit, direct boundary sampling). No tensor is retained; only Python numbers enter the records.
4. The node returns the telemetry as a strict-JSON string (`NaN`/`Infinity` never appear; failed fits become nulls) next to the normal `output` and `denoised_output` latents.

`docs/SPEED_SIGMA_HARVEST.md` documents the output schema and how to read a run.

## Commits

The commit titles, one per line, in the order they build on each other. Each commit is explained in its own comment on this pull request's conversation, posted in the same order.

- ce53cea refactor: share automatic SPEED config construction
- c9b1410 feat: add non-invasive SPEED runtime observer hooks
- 099a099 feat: add torch-native online spectral analysis
- ef9ab0f feat: add continuous SPEED sigma harvest node
- 11a625e docs: document continuous SPEED spectrum telemetry
- 8bd86b2 docs/diagnostics: identify native Sigma Harvest measurement basis
- 87b94e5 chore: remove temporary FLOW-PRODUCED header comments

## Verification

Full test suite on the branch tip (Python 3.12.13, headless venv):

- `/workspace/projects/minimax/minimax_speed/.venv/bin/python -m pytest speed_scripts/tests/ -q` — 126 passed, 5 skipped (both before and after the cleanup commit; the 5 skips are the pre-existing `speed_lab` sibling deselects).
- `grep -rn "FLOW-PRODUCED" nodes/ speed_scripts/ docs/ README.md __init__.py` — 0 matches after commit 87b94e5.

An independent review of the full diff against the implementation plan's hard rules found no critical issues: the observer cannot alter generation, no tensors are retained in records, JSON serialization is strict, failed fits become nulls, the x0 and residual namespaces are never blended, direct and extrapolated measurements are labelled, and no files outside the plan's scope were behaviorally modified.

## Intentional exclusions

Three validation steps belong on real hardware and are follow-ups on the T4 box, not part of this pull request:

- Real H3 GPU validation that an observed run produces output identical to an unobserved run (plan §59).
- An instrumentation overhead measurement — total runtime, per-step analysis time, peak VRAM (plan §57).
- Real 2/3/4-stage harvest experiments across several seeds and prompts (plan §60).

Also note: the old 3/4-stage benchmark evidence in the README predates the global transition-schedule fix merged in PR #37. That evidence must be rerun before any comparison against harvester data (plan §67). The README carries this warning.

## Rollback

Revert the seven commits or close this pull request. No stored data or external state is affected; the node is additive and unused by existing workflows.
