### PR TITLE
fix: complete the 3-stage conservative defaults (DESCRIPTION + Sigma Harvest schema + tests)

### DIFF
--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -33,7 +33,7 @@ class MiniMaxH3SPEEDSampler:
     DESCRIPTION = (
         "Automatic SPEED sampler — pick stages (2, 3, or 4) and go. "
         "Starts cheap at low resolution, then upsamples when the detail "
-        "matters. Set Tolerance (1% = 0.01) to trade blur for speed. "
+        "matters. Set Tolerance (0.5% = 0.005) to trade blur for speed. "
         "Uses baked A/beta; re-calibrate with the Harvest node if you "
         "change checkpoint."
     )

--- a/nodes/sampler_speed_sigma_harvest_node.py
+++ b/nodes/sampler_speed_sigma_harvest_node.py
@@ -56,9 +56,9 @@ class MiniMaxH3SPEEDSigmaHarvest:
                 "latent_image": ("LATENT",),
                 "stages": ("INT", {"default": 3, "min": 2, "max": 4}),
                 "noise_policy": (["direct_coarse", "coupled_full_grid"], {"default": "direct_coarse"}),
-                "Tolerance (Delta)": ("FLOAT", {"default": 0.01, "min": 1e-4, "max": 0.5, "step": 0.001}),
-                "noise_amplitude": ("FLOAT", {"default": 7.394, "min": 0.0, "max": 1e6, "step": 0.001, "round": 0.001}),
-                "noise_decay_exponent": ("FLOAT", {"default": 0.62, "min": 0.0, "max": 10.0, "step": 0.001, "round": 0.001}),
+                "Tolerance (Delta)": ("FLOAT", {"default": 0.005, "min": 1e-4, "max": 0.5, "step": 0.001}),
+                "noise_amplitude": ("FLOAT", {"default": 12.105, "min": 0.0, "max": 1e6, "step": 0.001, "round": 0.001}),
+                "noise_decay_exponent": ("FLOAT", {"default": 0.773, "min": 0.0, "max": 10.0, "step": 0.001, "round": 0.001}),
                 "seed_offset": ("INT", {"default": 10000, "min": 0, "max": 2**31 - 1}),
                 "measurement_mode": (["both", "x0_only", "residual_only"], {"default": "both"}),
                 "analysis_stride": ("INT", {"default": 1, "min": 1, "max": 1000}),
@@ -70,7 +70,7 @@ class MiniMaxH3SPEEDSigmaHarvest:
 
     def sample(self, noise, guider, sigmas, latent_image, stages=3,
                noise_policy="direct_coarse",
-               noise_amplitude=7.394, noise_decay_exponent=0.62,
+               noise_amplitude=12.105, noise_decay_exponent=0.773,
                seed_offset=10000,
                measurement_mode="both", analysis_stride=1,
                smoothing_alpha=0.25, boundary_band_half_width=1.0,
@@ -80,7 +80,7 @@ class MiniMaxH3SPEEDSigmaHarvest:
         delta = kwargs.get("Tolerance (Delta)",
                 kwargs.get("Tolerance",
                 kwargs.get("tolerance",
-                kwargs.get("delta", kwargs.get("Delta", 0.01)))))
+                kwargs.get("delta", kwargs.get("Delta", 0.005)))))
         if "preset" in kwargs:
             preset = kwargs.pop("preset")
             stages = PRESET_TO_STAGES.get(preset, stages)

--- a/speed_scripts/tests/test_automatic_config.py
+++ b/speed_scripts/tests/test_automatic_config.py
@@ -52,7 +52,8 @@ def _node_config(latent, **overrides):
 
 
 def test_input_schema_widgets_and_required_inputs():
-    """Regression: the Automatic node's required inputs and defaults are unchanged."""
+    """Regression: the Automatic node's required inputs and widget defaults
+    stay as shipped (calibration defaults may move; the schema shape may not)."""
     mod = importlib.import_module("sampler_node")
     required = mod.MiniMaxH3SPEEDSampler.INPUT_TYPES()["required"]
     for key in ("noise", "guider", "sigmas", "latent_image", "stages"):
@@ -68,10 +69,10 @@ def test_input_schema_widgets_and_required_inputs():
         ["direct_coarse", "coupled_full_grid"], {"default": "direct_coarse"},
     )
     assert required["Tolerance (Delta)"] == (
-        "FLOAT", {"default": 0.01, "min": 1e-4, "max": 0.5, "step": 0.001},
+        "FLOAT", {"default": 0.005, "min": 1e-4, "max": 0.5, "step": 0.001},
     )
-    assert required["noise_amplitude"][1]["default"] == 7.394
-    assert required["noise_decay_exponent"][1]["default"] == 0.62
+    assert required["noise_amplitude"][1]["default"] == 12.105
+    assert required["noise_decay_exponent"][1]["default"] == 0.773
     assert required["seed_offset"][1]["default"] == 10000
 
 


### PR DESCRIPTION
## What this changes

The Automatic SPEED sampler node now ships with the "3-stage conservative fit" defaults: Tolerance (Delta) 0.005, noise_amplitude 12.105, noise_decay_exponent 0.773. Commit b72d337 on dev already moved those three widget defaults; this PR completes that change in the three places it did not reach:

- The node's `DESCRIPTION` still said "Set Tolerance (1% = 0.01)". It now says "Set Tolerance (0.5% = 0.005)".
- The SPEED Sigma Harvest (continuous) node mirrors the Automatic node's generation-input schema. Its inputs still showed the old values, so the two nodes disagreed out of the box. It now shows the same three new defaults.
- Two test assertions in `speed_scripts/tests/test_automatic_config.py` pinned the old values. They now pin the new ones, and the test's docstring no longer claims the defaults "are unchanged".

## Why this change exists

Right now, dev fails its own test suite. At b72d337, two tests fail: the pinned-defaults assertion in `test_automatic_config.py`, and the schema-equality assertion in `test_speed_sigma_harvest_node.py` that requires every shared generation input of the Sigma Harvest node to exactly match the Automatic node's spec. This PR makes the suite green again and makes the values a user actually sees consistent across both nodes and the node's own description text.

## Commits

- 75ea54a fix: default Automatic node to the 3-stage conservative fit (Δ0.005 A12.105 β0.773) — explained in its own comment below.

## Verification

- Full suite: `/workspace/projects/minimax/minimax_speed/.venv/bin/python -m pytest speed_scripts/tests/ -q` → 131 passed, 6 skipped. Baseline before any change was identical (131 passed, 6 skipped), so no regressions.
- On dev at b72d337 before this change, the two affected test files alone ran 2 failed, 22 passed. With this PR, the full suite is green.
- An introspection script confirmed both node classes now report 0.005 / 12.105 / 0.773, `stages` stays 3, the `sample()` signature defaults match the widgets, and `DESCRIPTION` contains "0.5% = 0.005".

## Risks and review focus

Saved workflows that already set these widgets keep their values; only runs that omit them pick up the new defaults. That is the intent: new generations start sharper (the conservative fit from the refreshed 0.5MP calibration) at the cost of some speed. The values themselves were chosen in b72d337; this PR only completes the surrounding surfaces.

## Intentional exclusions

- `nodes/sampler_node_manual.py` (Manual node keeps its own 7.394 / 0.62 values — not asked for).
- `nodes/sampler_sigma_harvest_node.py` (native harvest node; its Tolerance field is an optional filter input, not part of the shared schema).
- `speed_scripts/config.py` `SpeedConfig` dataclass defaults (the node path always passes explicit values).
- `AGENTS.md` still describes the old defaults in passing — a docs follow-up.
