### PR TITLE
revert: out-of-scope sigma trace + marker changes

### DIFF
--- a/docs/SPEED_SIGMA_HARVEST.md
+++ b/docs/SPEED_SIGMA_HARVEST.md
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED
 # SPEED Sigma Harvest (Continuous) — measurement reference
 
 `SPEED Sigma Harvest (Continuous)` is the node

--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §7 (commit 1) — flow-produced, do not hand-edit
 """Automatic SPEED sampler — uses LatentWalker to own the I2V keyframe
 lifecycle across the SPEED stage boundaries.
 

--- a/nodes/sampler_sigma_trace_node.py
+++ b/nodes/sampler_sigma_trace_node.py
@@ -94,15 +94,8 @@ def _spatial_band_powers(video: torch.Tensor) -> dict[str, Any]:
     H, W = int(video.shape[-2]), int(video.shape[-1])
     if H < 2 or W < 2:
         return empty
-    # Band edges on the smaller spatial axis. High band is kept non-empty by
-    # requiring mid_cut < min(H, W); otherwise that band would mean() over an
-    # empty selection and yield NaN.
     low_cut = max(1, min(H, W) // 3)
     mid_cut = max(low_cut + 1, 2 * min(H, W) // 3)
-    if mid_cut >= min(H, W):
-        mid_cut = min(H, W) - 1
-        if mid_cut <= low_cut:
-            return empty
     try:
         coeffs = _dct2(video.detach().float())
     except Exception:
@@ -113,19 +106,13 @@ def _spatial_band_powers(video: torch.Tensor) -> dict[str, Any]:
         SPATIAL_BAND_NAMES[1]: (..., slice(low_cut, mid_cut), slice(0, W)),
         SPATIAL_BAND_NAMES[2]: (..., slice(mid_cut, H), slice(0, W)),
     }
-    # Per-frame band energy: sum |coeff|^2 over batch, channel, rows and columns,
-    # keeping the time axis so each band series has one entry per frame, length T.
-    band_energy = [
-        power[slices].sum(dim=(0, 1, 3, 4))  # [T]
-        for slices in band_slices.values()
-    ]
-    # Per-frame total energy across all coefficients: the three bands sum to
-    # 1.0 at every frame index (a global-sum normaliser would give 1/W).
-    frame_total = power.sum(dim=(1, 3, 4)).squeeze(0)  # [T] (batch is 1)
     powers: list[list[float]] = []
-    for band_sum in band_energy:
-        per_frame = torch.where(frame_total > 0.0, band_sum / frame_total.clamp_min(1e-30), torch.zeros_like(band_sum))
+    for band_name in SPATIAL_BAND_NAMES:
+        per_frame = power[band_slices[band_name]].mean(dim=(0, 1, 2, 3))  # [T]
         powers.append([float(v) for v in per_frame.detach().cpu().tolist()])
+    total_energy = float(power.sum().item())
+    if total_energy > 0.0:
+        powers = [[p / total_energy for p in band_powers] for band_powers in powers]
     return {"bands": list(SPATIAL_BAND_NAMES), "powers": powers, "n_frames": n_frames}
 
 
@@ -154,6 +141,19 @@ def _temporal_band_summary(video: torch.Tensor) -> dict[str, Any]:
     }
 
 
+def _coerce_sigma(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return float(value.detach().reshape(()).item())
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _sigma_list(sigmas: Any) -> list[float]:
     if isinstance(sigmas, torch.Tensor):
         return [float(v) for v in sigmas.detach().reshape(-1).cpu().tolist()]
@@ -171,11 +171,70 @@ def _sigma_list(sigmas: Any) -> list[float]:
         return []
 
 
-def _build_callback(records: list, sigmas: Any, patcher: Any = None) -> Any:
+def _n_sigma_steps(sigmas: Any) -> int:
+    if isinstance(sigmas, torch.Tensor):
+        return sigmas.numel()
+    if isinstance(sigmas, (list, tuple)):
+        return len(sigmas)
+    return 0
+
+
+def _build_callback(records: list, sigmas: Any) -> Any:
     """Wrap a stock `latent_preview.prepare_callback` so it still drives the
     ComfyUI progress/preview pipeline, then append one telemetry record per step.
-    Pass the real model patcher on the runtime path so the live previewer is
-    actually used; without it the stock callback degrades to a ProgressBar.
+    """
+    sig = _sigma_list(sigmas)
+    n_steps = max(0, len(sig) - 1)
+    x0_output: dict = {}
+    stock_cb = None
+    if _lp is not None:
+        try:
+            stock_cb = _lp.prepare_callback(None, n_steps, x0_output)
+        except Exception:
+            stock_cb = None
+    if stock_cb is None:
+        pbar = comfy.utils.ProgressBar(n_steps)
+        def _stock_fallback(step, x0, x, total_steps):
+            pbar.update_absolute(step + 1, total_steps)
+        stock_cb = _stock_fallback
+
+    def _callback(step, x0, x, total_steps):
+        si = int(step)
+        sigma_now = sig[si] if 0 <= si < len(sig) else None
+        sigma_next = sig[si + 1] if 0 <= si + 1 < len(sig) else None
+        x0_nested = x0 if (hasattr(x0, "is_nested") and x0.is_nested) else None
+        x0_video = _extract_video_stream(x0)
+        record: dict[str, Any] = {
+            "step_index": si,
+            "sigma": sigma_now,
+            "sigma_next": sigma_next,
+            "sigma_source": "schedule" if sigma_now is not None else "missing",
+            "latent_shapes": {"x0": _extract_nested_shapes(x0_nested)},
+            "video_shape": list(x0_video.shape) if x0_video is not None else None,
+            "signal": _signal_stats(x0_video) if x0_video is not None else {
+                "mean": None, "std": None, "rms": None,
+                "min": None, "max": None, "abs_mean": None,
+            },
+            "spatial_dct": _spatial_band_powers(x0_video) if x0_video is not None else {
+                "bands": list(SPATIAL_BAND_NAMES),
+                "powers": [[0.0] for _ in SPATIAL_BAND_NAMES],
+                "n_frames": 0,
+            },
+            "temporal_dct": _temporal_band_summary(x0_video) if x0_video is not None else {
+                "available": False, "reason": "no_video_tensor", "power": [],
+            },
+            "status": "ok",
+            "measurement_note": MEASURED_TENSOR,
+        }
+        records.append(record)
+        return stock_cb(step, x0, x, total_steps)
+
+    return _callback, x0_output
+
+
+def _open_video_stream_callback(records: list, sigmas: Any, patcher: Any) -> Any:
+    """Variant for the real runtime path: pass the real patcher so ComfyUI's
+    previewer is actually used and the live preview works on H3.
     """
     sig = _sigma_list(sigmas)
     n_steps = max(0, len(sig) - 1)
@@ -223,11 +282,13 @@ def _build_callback(records: list, sigmas: Any, patcher: Any = None) -> Any:
         records.append(record)
         return stock_cb(step, x0, x, total_steps)
 
-    return _callback, x0_output
+    return _callback
 
 
 def _trace_callback(patcher: Any, sigmas: torch.Tensor, records: list) -> Any:
-    return _build_callback(records, sigmas, patcher)[0]
+    if patcher is None:
+        return _build_callback(records, sigmas)[0]
+    return _open_video_stream_callback(records, sigmas, patcher)
 
 
 class MiniMaxH3SigmaTrace:

--- a/nodes/sampler_speed_sigma_harvest_node.py
+++ b/nodes/sampler_speed_sigma_harvest_node.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §4-6, 17, 48 (commit 4) — flow-produced, do not hand-edit
 """SPEED Sigma Harvest (Continuous) — diagnostic node.
 
 Runs ONE real multi-stage SPEED generation (the same `run_speed_pipeline` the

--- a/speed_scripts/automatic_config.py
+++ b/speed_scripts/automatic_config.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §7 (commit 1) — flow-produced, do not hand-edit
 """Shared automatic SPEED config construction.
 
 The Automatic SPEED sampler and the SPEED Sigma Harvest diagnostic node must

--- a/speed_scripts/observer.py
+++ b/speed_scripts/observer.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §8-12 (commit 2) — flow-produced, do not hand-edit
 """Runtime observer contract for the multi-stage SPEED pipeline.
 
 `run_speed_pipeline` notifies an optional observer about what the run does:

--- a/speed_scripts/online_harvest.py
+++ b/speed_scripts/online_harvest.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §17-26, 30, 35, 42 (commits 3-4) — flow-produced, do not hand-edit
 """Torch-native online spectral analysis for continuous SPEED sigma harvesting.
 
 Per-step companion to :mod:`speed_scripts.harvest`: measures the radial DCT

--- a/speed_scripts/tests/test_automatic_config.py
+++ b/speed_scripts/tests/test_automatic_config.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §56 (commit 1) — flow-produced, do not hand-edit
 """Config-equivalence and schema regression tests for the shared automatic
 SPEED config builder (speed_scripts/automatic_config.py).
 

--- a/speed_scripts/tests/test_online_harvest.py
+++ b/speed_scripts/tests/test_online_harvest.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §49 (commit 3) — flow-produced, do not hand-edit
 """Pure-math tests for the torch-native online spectral analysis (§49)."""
 
 from __future__ import annotations

--- a/speed_scripts/tests/test_runtime_observer.py
+++ b/speed_scripts/tests/test_runtime_observer.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §50-54 (commit 2) — flow-produced, do not hand-edit
 """Runtime observer hook tests.
 
 Runs `run_speed_pipeline` with the same fake guider/noise infrastructure as

--- a/speed_scripts/tests/test_sigma_trace_node.py
+++ b/speed_scripts/tests/test_sigma_trace_node.py
@@ -210,17 +210,6 @@ def test_trace_runs_one_native_pass_and_preserves_every_callback(trace_env):
             predicted_video.square().mean().sqrt().item(), rel=1e-5
         )
         assert set(entry["spatial_dct"]["bands"]) == {"low", "mid", "high"}
-        powers = entry["spatial_dct"]["powers"]
-        # one entry per frame per band (F1 regression: frame axis collapsed -> len W)
-        assert all(len(series) == video.shape[2] for series in powers)
-        # the three bands sum to 1.0 at every frame index (F2 regression: 1/W)
-        band_sums = [
-            sum(powers[band_idx][frame_idx] for band_idx in range(len(powers)))
-            for frame_idx in range(video.shape[2])
-        ]
-        assert all(total == pytest.approx(1.0, rel=1e-3) for total in band_sums)
-        # no NaN from empty band slices (F3 regression: H<3 -> NaN high band)
-        assert all(math.isfinite(v) for series in powers for v in series)
         assert entry["temporal_dct"]["available"] is True
         assert len(entry["temporal_dct"]["power"]) == video.shape[2]
         assert trace_env.previews[step][0] == step

--- a/speed_scripts/tests/test_speed_sigma_harvest_node.py
+++ b/speed_scripts/tests/test_speed_sigma_harvest_node.py
@@ -1,3 +1,4 @@
+# FLOW-PRODUCED — Implementation Plan — Continuous SPEED Sigma Harvester.md §55-56 (commit 4) — flow-produced, do not hand-edit
 """Node tests for the continuous SPEED Sigma Harvest (plan §55, §56).
 
 Drives `run_speed_pipeline` through the node with the same fake


### PR DESCRIPTION
## What this changes

This pull request reverses two change sets that landed on `dev` but are out of scope for the current release. It restores file contents directly; it is not a mechanical `git revert`, because several later commits touched the same files and must survive.

1. `nodes/sampler_sigma_trace_node.py` and `speed_scripts/tests/test_sigma_trace_node.py` go back to their state before commit `533ccb0` ("Fix Sigma Trace spatial band math: per-frame energy fractions"). The node returns to the earlier band-math behavior: the F1/F2/F3 spatial bands are averaged over `(0, 1, 2, 3)` with a single global `total_energy` normalization, the `mid_cut` band-edge clamp is gone, and the helpers `_coerce_sigma` / `_n_sigma_steps` and the single-callback `_open_video_stream_callback` shape come back. Both files are byte-identical to `0725a35d`, the commit that introduced the Sigma Trace feature.
2. The first-line `# FLOW-PRODUCED — ...` marker comment comes back on the 10 files that commit `87b94e5` ("chore: remove temporary FLOW-PRODUCED header comments") cleaned: `docs/SPEED_SIGMA_HARVEST.md`, `nodes/sampler_node.py`, `nodes/sampler_speed_sigma_harvest_node.py`, `speed_scripts/automatic_config.py`, `speed_scripts/observer.py`, `speed_scripts/online_harvest.py`, and the test files `speed_scripts/tests/test_automatic_config.py`, `test_online_harvest.py`, `test_runtime_observer.py`, `test_speed_sigma_harvest_node.py`.

## Why this change exists

The Sigma Trace band-math fix and the marker cleanup were judged out of scope for the current release line. This PR deliberately reinstates the pre-fix behavior and the markers. Reinstating the old band-math behavior is intentional; it should not be "fixed" here.

## What was deliberately preserved

Later commits that touched the same files survive intact:

- The conservative defaults change `b72d337` ("fix: use conserverative stage 3") — `Tolerance (Delta)` 0.005, `noise_amplitude` 12.105, `noise_decay_exponent` 0.773 in `nodes/sampler_node.py` (INPUT_TYPES, `sample()` signature, and DESCRIPTION fallback) — is still in place below the restored marker line.
- The PR #38 review amendments from `0784c27` are untouched in `speed_scripts/online_harvest.py` and the three test files `test_online_harvest.py`, `test_runtime_observer.py`, `test_speed_sigma_harvest_node.py`.

## Test changes

The three F1/F2/F3 regression assertions that `533ccb0` added to `speed_scripts/tests/test_sigma_trace_node.py` assume the fixed band math and would fail against the reverted node. They are rolled back with the feature: the test file is restored to its pre-`533ccb0` state. No other test file was modified.

## Commits

- revert: sigma trace band math + FLOW-PRODUCED markers (out of scope)

## Verification

- `git diff origin/dev --stat` shows exactly the 12 intended files (10 marker files plus the 2 sigma-trace files), 94 insertions / 34 deletions, and `git diff origin/dev --check` is clean.
- `git diff 0725a35d 051854e -- nodes/sampler_sigma_trace_node.py speed_scripts/tests/test_sigma_trace_node.py` is empty: both files are byte-identical to the pre-fix state.
- Each of the 10 marker files differs from its `dev` version by exactly one added first line; everything below line 1 is byte-identical to `dev`.
- Full suite in a clean worktree: `/workspace/projects/minimax/minimax_speed/.venv/bin/python -m pytest speed_scripts/tests/ -q` → 129 passed, 6 skipped, 2 failed. The 2 failures (`test_automatic_config.py::test_input_schema_widgets_and_required_inputs`, `test_speed_sigma_harvest_node.py::test_node_schema_and_registration`) also fail on `dev` at `b72d337`: both assert the old default `Tolerance (Delta)` of 0.01 while the preserved defaults change sets 0.005. They are pre-existing on `dev` and are intentionally left out of scope here.
- An independent reviewer re-verified the diff scope, byte-identity, marker preservation, and defaults preservation from the commit itself; all checks passed.

## Risks and review focus

- The only change in the 10 marker files is line 1. None of the 10 files starts with a shebang or encoding comment (all start with a docstring or markdown heading), so prepending a `#` comment line is safe.
- The two pre-existing test failures on `dev` (old 0.01 default asserted vs. the preserved 0.005) exist on `dev` today; this PR neither fixes nor worsens them. A follow-up could align those assertions with the conservative defaults.

## Rollback

Merging this PR changes only file contents in the repository. Undo it by reverting this PR's single commit.
