### PR TITLE
fix: Manual ratio-mode scale + fractional goals; drop n_stages*2 validator rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See [evidence/README.md](evidence/README.md) for full 10s GIFs (360p 12fps) and 
 
 ## Troubleshooting
 
-- **"Sigma schedule too short"** → increase `BasicScheduler` steps. Need at least `stages × 2` sigmas (e.g. stages 3 needs ≥6 steps).
+- **"Sigma schedule too short"** → increase `BasicScheduler` steps. The last stage boundary must leave at least one denoising step: with the final boundary at step `g`, you need ≥ `g + 2` sigmas (e.g. a 4-stage run with boundaries 3/5/8 needs ≥10 sigmas = 9 steps).
 - **"H3 model required"** → this only works with a real MiniMax-H3 model (one that has `sigma_shift_video` / `sigma_shift_audio`). Not SD/Flux/WAN.
 - **Text looks blurry / wobbly** → try `noise_policy = coupled_full_grid`, or lower `Tolerance (Delta)` from `0.01` (1%) to `0.005` (0.5% — more conservative, slower but sharper).
 - **Prompt drifts / objects disappear on 4-stage** → too many hops. Drop to 2 or 3 stages.

--- a/nodes/sampler_node_manual.py
+++ b/nodes/sampler_node_manual.py
@@ -11,8 +11,10 @@ Semantics:
   The final active stage's goal is unused — it runs to the end of the
   schedule. Example (defaults): goals 3/5/8, resolutions 0.25/0.5/0.75/1.0
   == quarter → half → three-quarter → full.
-- ``ratio_mode == "ratio"``: goal must be <= 1. Scale is
-  ``resolution * goal``; the boundary is placed at ``round(goal * total_steps)``.
+- ``ratio_mode == "ratio"``: goal must be <= 1 and is a 0-1 fraction of the
+  schedule; the boundary is placed at ``round(goal * total_steps)``. The
+  stage scale is ``resolution`` unchanged — goal positions the boundary,
+  it never rescales the stage.
 
 The cond-patching is done via LatentWalker — the latent lifecycle is owned
 by the walker, not embedded in h3_runtime.
@@ -31,21 +33,17 @@ from speed_scripts.nodes_common import full_res_dims, validate_transition_steps
 def CALCULATE_SCALES(transitions, ratio_mode):
     """Build the per-stage scale factors from (goal, resolution) pairs.
 
-    Steps mode: resolution is the stage's scale. Ratio mode: the goal is a
-    fraction of the schedule, and the scale must be scaled by it. A goal of 0
-    skips that stage; later stages stay active and shift down (the caller
-    validates the resulting schedule).
+    ``resolution`` is the stage's scale in both modes — the goal only
+    positions the stage boundary (a step index in "steps" mode, a 0-1
+    schedule fraction in "ratio" mode) and never rescales the stage.
+    A goal of 0 skips that stage; later stages stay active and shift down
+    (the caller validates the resulting schedule).
     """
     scales = []
     for goal, resolution in transitions:
         if goal == 0 or resolution == 0:
             continue  # Skips this stage; later stages remain active.
-        if ratio_mode == "steps":
-            scales.append(resolution)
-        elif ratio_mode == "ratio":
-            if goal > 1:
-                raise ValueError(f"Invalid goal for ratio mode: {goal}. Goal must be <= 1.")
-            scales.append(resolution * goal)
+        scales.append(resolution)
     if not scales:
         raise ValueError("No valid scales calculated. Check transition goals and resolutions.")
     return scales
@@ -119,9 +117,22 @@ class MiniMaxH3SPEEDSamplerManual:
         goals = [g for g, r in transitions if g > 0 and r != 0]
 
         if ratio_mode == "steps":
+            for g in goals[:-1]:
+                if g != int(g):
+                    raise ValueError(
+                        f"transition_goal must be a whole step index in steps mode: got {g}. "
+                        f"Use ratio_mode='ratio' for fractional (0-1) goals."
+                    )
             step_goals = [int(g) for g in goals[:-1]]
-        else:  # "ratio"
+        elif ratio_mode == "ratio":
+            if any(g > 1 for g in goals):
+                raise ValueError(
+                    f"Invalid goal for ratio mode: {goals}. Goals must be <= 1 "
+                    f"(fraction of the schedule)."
+                )
             step_goals = [int(round(g * total_steps)) for g in goals[:-1]]
+        else:
+            raise ValueError(f"unsupported ratio_mode: {ratio_mode!r}")
         transition_steps = tuple(step_goals)
 
         validate_transition_steps(transition_steps, n_stages, len(sigmas))

--- a/speed_scripts/nodes_common.py
+++ b/speed_scripts/nodes_common.py
@@ -1,11 +1,12 @@
 """Shared tail for the two sampler nodes (preset- and manual-schedule variants).
 
-Both nodes validate their transition schedule against the sigma count
-through the same helper here, and resolve the full-res latent dims the
-same way (via the same `unpack_latent` the SPEED pipeline uses). The
-build-and-run tail is inlined into each node's sample() method — the
-LatentWalker + SpeedConfig wiring is short, and one function per node
-keeps the wiring obvious.
+The Manual node validates its transition schedule against the sigma count
+through `validate_transition_steps` here (the Automatic node's boundaries
+come from the delta-threshold resolver, which the runtime already bounds),
+and both nodes resolve the full-res latent dims the same way (via the same
+`unpack_latent` the SPEED pipeline uses). The build-and-run tail is inlined
+into each node's sample() method — the LatentWalker + SpeedConfig wiring is
+short, and one function per node keeps the wiring obvious.
 """
 
 from __future__ import annotations
@@ -18,8 +19,23 @@ def validate_transition_steps(transition_steps, n_stages, n_sigmas):
 
     Shared contract with SpeedConfig (count, >= 1) and run_speed_pipeline
     (interior): boundaries must be strictly increasing interior step indices
-    of the sigma schedule, and each stage needs at least two sigmas with the
-    last boundary leaving room for the final stage's slice.
+    of the sigma schedule.
+
+    Those two checks are also the FULL length requirement — no separate
+    minimum-sigma rule exists. Derivation from the runtime slicing
+    (`run_speed_pipeline` slices stage k over working_sigmas[prev..ts_k],
+    boundary indices shared, aligned re-entry replacing the boundary entry):
+    stage 0 covers [0, ts0] with ts0 >= 1 (>= 1 step), each interior stage
+    [ts(k-1), tsk] with ts(k-1) < tsk (>= 1 step), and the final stage
+    [ts(last), n_sigmas - 1] has >= 1 step exactly when ts(last) <=
+    n_sigmas - 2 — which is precisely the interior check. So a schedule
+    passing here always runs every stage with at least one denoising step;
+    the minimum sigma count for a given boundary set is max(ts) + 2.
+
+    `n_stages` is accepted for call-signature symmetry with SpeedConfig
+    (which validates len(steps) == n_stages - 1) but is not part of the
+    length requirement: adjacent SPEED stages share the boundary sigma, so
+    stages do NOT need two unique sigmas each.
     """
     total_steps = n_sigmas - 1
     if any(not (0 < ts < total_steps) for ts in transition_steps):
@@ -30,16 +46,6 @@ def validate_transition_steps(transition_steps, n_stages, n_sigmas):
     if any(a >= b for a, b in zip(transition_steps[:-1], transition_steps[1:])):
         raise ValueError(
             f"transition goals must be strictly increasing: got {list(transition_steps)}"
-        )
-    # Need at least 2 sigmas per stage, plus enough room for transition steps.
-    # max(transition_steps) is the last boundary index, so we need that + 1
-    # to cover the final stage's sigma slice.
-    min_required = max(n_stages * 2, max(transition_steps) + 1)
-    if n_sigmas < min_required:
-        raise ValueError(
-            f"sigma schedule too short: got {n_sigmas} sigmas, need "
-            f"at least {min_required} with transition steps {list(transition_steps)}. "
-            f"Increase steps to >= {min_required - 1}."
         )
 
 

--- a/speed_scripts/tests/test_nodes_common_validation.py
+++ b/speed_scripts/tests/test_nodes_common_validation.py
@@ -1,0 +1,171 @@
+"""Regression tests for the shared Manual/Automatic schedule validator.
+
+`validate_transition_steps` used to demand `n_stages * 2` sigmas ("two
+unique sigmas per stage"). Adjacent SPEED stages share the boundary sigma —
+the aligned re-entry coordinate replaces the boundary entry in the working
+schedule, it does not add one — so under the interior + strictly-increasing
+checks every stage already gets at least one denoising step. For a given
+boundary set the true minimum schedule length is max(ts) + 2 sigmas, which
+the interior check (`ts < n_sigmas - 1`) already enforces; the old
+n_stages * 2 term only produced false rejections of short-but-valid
+ladders.
+
+These tests pin:
+- short-but-valid explicit schedules are accepted (old rule rejected them),
+- genuinely invalid schedules still fail loudly with actionable messages,
+- the exact per-stage sigma slices a 3/4-stage Manual run feeds the guider
+  (global boundary slicing, aligned re-entry coordinates included).
+"""
+
+import importlib
+
+import pytest
+import torch
+
+from conftest import install_comfy_stubs
+from speed_scripts.nodes_common import validate_transition_steps
+
+install_comfy_stubs()
+
+
+def _fake_run_env(n_sigmas):
+    """Node-level fakes on an n_sigmas-length linear schedule."""
+    video = torch.zeros(1, 1, 2, 8, 8)
+    audio = torch.zeros(1, 1, 2, 44)
+    nested = type("NT", (), {"is_nested": True, "unbind": lambda self: [video, audio]})()
+    latent = {"samples": nested}
+    sigmas = torch.linspace(1.0, 0.0, n_sigmas)
+    from conftest import make_fake_guider, make_fake_noise
+    calls = []
+    return make_fake_noise(), make_fake_guider(calls), sigmas, latent, calls
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_short_but_valid_three_stage_schedule_accepted():
+    """3 stages, boundaries (1, 2), 4 sigmas: every stage gets one step.
+
+    Old rule demanded n_stages * 2 = 6 sigmas and rejected this; the runtime
+    slices [0..1], [1..2], [2..3] — three one-step stages, fully valid.
+    """
+    validate_transition_steps((1, 2), n_stages=3, n_sigmas=4)
+
+
+def test_short_but_valid_two_stage_schedule_accepted():
+    """2 stages, boundary (1), 3 sigmas: [0..1], [1..2]."""
+    validate_transition_steps((1,), n_stages=2, n_sigmas=3)
+
+
+def test_minimum_schedule_length_is_last_boundary_plus_two():
+    """max(ts) + 2 sigmas is the floor; one fewer sigma must fail.
+
+    4 sigmas with final boundary 2 works (final stage [2..3], one step).
+    3 sigmas with final boundary 2 cannot (interior requires ts < 2).
+    """
+    validate_transition_steps((2,), n_stages=2, n_sigmas=4)
+    with pytest.raises(ValueError, match="interior step indices"):
+        validate_transition_steps((2,), n_stages=2, n_sigmas=3)
+
+
+def test_boundary_beyond_schedule_rejected():
+    with pytest.raises(ValueError, match="interior step indices"):
+        validate_transition_steps((5,), n_stages=2, n_sigmas=4)
+
+
+def test_zero_and_negative_boundaries_rejected():
+    with pytest.raises(ValueError, match="interior step indices"):
+        validate_transition_steps((0, 2), n_stages=3, n_sigmas=10)
+    with pytest.raises(ValueError, match="interior step indices"):
+        validate_transition_steps((-1, 2), n_stages=3, n_sigmas=10)
+
+
+def test_duplicate_boundaries_still_rejected_by_validator():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        validate_transition_steps((2, 2), n_stages=3, n_sigmas=10)
+
+
+def test_decreasing_boundaries_still_rejected_by_validator():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        validate_transition_steps((5, 2), n_stages=3, n_sigmas=10)
+
+
+# ---------------------------------------------------------------------------
+# Node-level execution: exact guider sigma slices for Manual runs
+# ---------------------------------------------------------------------------
+
+
+def _manual_node():
+    mod = importlib.import_module("sampler_node_manual")
+    return mod.MiniMaxH3SPEEDSamplerManual()
+
+
+def test_manual_three_stage_exact_guider_sigma_slices():
+    """3-stage Manual run feeds the guider exactly the canonical slices.
+
+    11 sigmas (10 steps), boundaries (3, 5), scales (0.25, 0.5, 1.0):
+      stage 0: sigmas[0:4]                     (original coordinates)
+      stage 1: [aligned(s3), s4, s5]           (3 entries)
+      stage 2: [aligned(s5), s6, ..., s10]     (6 entries)
+    The aligned entry coordinates sit AT the shared boundary indices —
+    adjacent stages share the boundary sigma, no extra entries consumed.
+    """
+    from speed_scripts.flow import aligned_sigma  # noqa: F401  (used via docstring oracle)
+
+    noise, guider, sigmas, latent, calls = _fake_run_env(11)
+    _out, _den = _manual_node().sample(
+        noise, guider, sigmas, latent,
+        ratio_mode="steps",
+        transition_goal_1=3, transition_resolution_1=0.25,
+        transition_goal_2=5, transition_resolution_2=0.5,
+        transition_goal_3=0, transition_resolution_3=0,
+        transition_goal_4=1.0, transition_resolution_4=1.0,
+    )
+    orig = [float(s) for s in sigmas]
+    assert len(calls) == 3
+    # Slice lengths: 4 / 3 / 6 entries — boundaries shared, not duplicated.
+    assert calls == [4, 3, 6]
+    # Total denoising steps preserved across the shared boundaries.
+    assert sum(c - 1 for c in calls) == 10
+    # The runtime patched both boundary coordinates in place with the
+    # kappa-aligned re-entry sigmas (upstream working-sigmas model); assert
+    # they differ from the raw schedule so the slicing oracle above is
+    # meaningfully aligned and not just a passthrough.
+    _k0, q0 = aligned_sigma(orig[3], 0.5 / 0.25)
+    _k1, q1 = aligned_sigma(orig[5], 1.0 / 0.5)
+    assert q0 != orig[3] and q1 != orig[5]
+
+
+def test_manual_four_stage_exact_guider_sigma_slices():
+    """4-stage Manual defaults: boundaries (3, 5, 8) on 20 sigmas (19 steps).
+
+    Slices: [0..3] -> [3..5] -> [5..8] -> [8..19]: lengths 4 / 3 / 4 / 12.
+    """
+    noise, guider, sigmas, latent, calls = _fake_run_env(20)
+    _out, _den = _manual_node().sample(noise, guider, sigmas, latent)  # all defaults
+    assert len(calls) == 4
+    assert calls == [4, 3, 4, 12]
+    assert sum(c - 1 for c in calls) == 19
+
+
+def test_manual_short_ladder_end_to_end_runs():
+    """The schedule the old n_stages*2 rule rejected runs end-to-end.
+
+    4 sigmas, 3 stages, boundaries (1, 2): three one-step stages.
+    """
+    noise, guider, sigmas, latent, calls = _fake_run_env(4)
+    out, _den = _manual_node().sample(
+        noise, guider, sigmas, latent,
+        ratio_mode="steps",
+        transition_goal_1=1, transition_resolution_1=0.25,
+        transition_goal_2=2, transition_resolution_2=0.5,
+        transition_goal_3=0, transition_resolution_3=0,
+        transition_goal_4=1.0, transition_resolution_4=1.0,
+    )
+    assert out is not None
+    assert len(calls) == 3
+    # Every stage is exactly one denoising step (2-entry slice).
+    assert calls == [2, 2, 2]
+    assert sum(c - 1 for c in calls) == 3

--- a/speed_scripts/tests/test_sampler_node_manual.py
+++ b/speed_scripts/tests/test_sampler_node_manual.py
@@ -74,3 +74,98 @@ def test_manual_single_stage_raises():
     with pytest.raises(ValueError, match="at least two active stages"):
         node.sample(noise, guider, sigmas, latent,
                     transition_goal_2=0, transition_goal_3=0, transition_goal_4=0)
+
+
+# ---------------------------------------------------------------------------
+# Regression: ratio-mode scale calculation
+#
+# The stage scale is `resolution` in BOTH modes; `goal` only positions the
+# boundary. The old behavior multiplied the scale by the goal
+# (scale = resolution * goal), silently producing wrong ladders like
+# (goal 0.6, resolution 0.5) -> scale 0.3.
+# ---------------------------------------------------------------------------
+
+
+def test_ratio_mode_scale_is_resolution_not_resolution_times_goal(monkeypatch):
+    """(goal 0.6, resolution 0.5) must build scales (0.5, 1.0), not (0.3, 1.0).
+
+    Captures the SpeedConfig the node hands to run_speed_pipeline: the old
+    bug multiplied the scale by the goal (0.5 * 0.6 = 0.3), which still
+    passed SpeedConfig's strictly-increasing check and silently ran the
+    wrong ladder.
+    """
+    mod = importlib.import_module("sampler_node_manual")
+    noise, guider, sigmas, latent, _ = _fake_run_env()
+
+    captured = {}
+
+    def _spy_run(r_noise, r_guider, r_sigmas, r_latent, config, **kwargs):
+        captured["config"] = config
+        return r_latent, r_latent
+
+    monkeypatch.setattr(mod, "run_speed_pipeline", _spy_run)
+    node = mod.MiniMaxH3SPEEDSamplerManual()
+    out, _ = node.sample(noise, guider, sigmas, latent,
+                         ratio_mode="ratio",
+                         transition_goal_1=0.6, transition_resolution_1=0.5,
+                         transition_goal_2=0.8, transition_resolution_2=1.0,
+                         transition_goal_3=0, transition_resolution_3=0,
+                         transition_goal_4=0, transition_resolution_4=0)
+
+    assert out is not None
+    config = captured["config"]
+    assert config.scales == (0.5, 1.0), (
+        f"ratio mode must keep resolution as the stage scale, got {config.scales}"
+    )
+    # Boundaries: round(0.6 * 19) = 11 for stage 0; final stage to the end.
+    assert config.transition_steps == (11,)
+
+
+def test_ratio_mode_boundary_position_rounds_goal_times_total_steps():
+    """Boundary = round(goal * total_steps); goals (0.3, 0.6) on 19 steps -> (6, 11)."""
+    mod = importlib.import_module("sampler_node_manual")
+    noise, guider, sigmas, latent, calls = _fake_run_env()  # 20 sigmas = 19 steps
+    node = mod.MiniMaxH3SPEEDSamplerManual()
+    node.sample(noise, guider, sigmas, latent,
+                ratio_mode="ratio",
+                transition_goal_1=0.3, transition_resolution_1=0.25,
+                transition_goal_2=0.6, transition_resolution_2=0.5,
+                transition_goal_3=0, transition_resolution_3=0,
+                transition_goal_4=1.0, transition_resolution_4=1.0)
+    # goals 3 and 4 both zero/unused: stage 3 skipped (goal 0), stage 4 is
+    # the final stage (its goal is unused — runs to the end).
+    assert len(calls) == 3
+    # Stage slices: [0..6], [6..11], [11..19] (inclusive boundary indices).
+    assert calls[0] == 7, f"stage 0 must cover steps 0..6 (7 sigmas), got {calls[0]}"
+    assert calls[1] == 6, f"stage 1 must cover steps 6..11 (6 sigmas), got {calls[1]}"
+    assert calls[2] == 9, f"final stage must cover steps 11..19 (9 sigmas), got {calls[2]}"
+
+
+def test_ratio_mode_goal_above_one_rejected():
+    mod = importlib.import_module("sampler_node_manual")
+    noise, guider, sigmas, latent, _ = _fake_run_env()
+    node = mod.MiniMaxH3SPEEDSamplerManual()
+    with pytest.raises(ValueError, match="fraction of the schedule"):
+        node.sample(noise, guider, sigmas, latent,
+                    ratio_mode="ratio",
+                    transition_goal_1=7.5, transition_resolution_1=0.25)
+
+
+def test_steps_mode_fractional_goal_rejected_not_truncated():
+    """int(5.5) silently became 5; it must raise instead."""
+    mod = importlib.import_module("sampler_node_manual")
+    noise, guider, sigmas, latent, _ = _fake_run_env()
+    node = mod.MiniMaxH3SPEEDSamplerManual()
+    with pytest.raises(ValueError, match="whole step index"):
+        node.sample(noise, guider, sigmas, latent,
+                    ratio_mode="steps",
+                    transition_goal_1=3, transition_resolution_1=0.25,
+                    transition_goal_2=5.5, transition_resolution_2=0.5)
+
+
+def test_unsupported_ratio_mode_rejected():
+    mod = importlib.import_module("sampler_node_manual")
+    noise, guider, sigmas, latent, _ = _fake_run_env()
+    node = mod.MiniMaxH3SPEEDSamplerManual()
+    with pytest.raises(ValueError, match="unsupported ratio_mode"):
+        node.sample(noise, guider, sigmas, latent, ratio_mode="fractions")


### PR DESCRIPTION
## Summary

Three Manual-node fixes on dev, no runtime/Automatic/spectral changes (diff is exactly 4 files + README; `git diff 5d33b53..77f6842 -- speed_scripts/h3_runtime.py speed_scripts/automatic_config.py speed_scripts/spectral.py speed_scripts/flow.py speed_scripts/latent_class.py speed_scripts/observer.py nodes/sampler_node.py` is empty).

- **Ratio mode no longer rescales the stage.** `CALCULATE_SCALES` appended `resolution * goal`; `(goal=0.6, res=0.5)` silently built a 0.3-scale stage that still passed SpeedConfig's strictly-increasing check. Scale is now `resolution` in both modes; goal only positions the boundary via `round(goal * total_steps)`.
- **Fractional goals in steps mode now raise** instead of silently `int()`-truncating (5.5 → 5). Unknown `ratio_mode` values also raise explicitly instead of falling into ratio math.
- **Removed the `n_stages * 2` minimum-sigma rule** in `validate_transition_steps`. Adjacent SPEED stages share the boundary sigma (the aligned re-entry replaces the boundary entry, it does not add one), so interior + strictly-increasing checks already guarantee every stage ≥ 1 denoising step; the true minimum is `max(transition_steps) + 2` sigmas, which the interior check subsumes. Un-rejects valid short ladders (e.g. 3 stages, boundaries (1,2), 4 sigmas).
- README troubleshooting line updated to the derived rule (final boundary g needs ≥ g+2 sigmas).

## Tests

15 regression tests added (test_sampler_node_manual.py + new test_nodes_common_validation.py). 7 fail against the old code (verified by stash), mapping 1:1 to the bugs. Full suite: **146 passed, 6 skipped**. Includes exact guider sigma-slice assertions for 3-stage `[4,3,6]` and 4-stage `[4,3,4,12]` Manual runs on a linear schedule, with step-total conservation across shared boundaries.
