### PR TITLE
Automatic SPEED: 4-decimal precision for noise_amplitude / noise_decay_exponent

### DIFF
--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -52,8 +52,8 @@ class MiniMaxH3SPEEDSampler:
                 "stages": ("INT", {"default": 3, "min": 2, "max": 4}),
                 "noise_policy": (["direct_coarse", "coupled_full_grid"], {"default": "direct_coarse"}),
                 "Tolerance (Delta)": ("FLOAT", {"default": 0.005, "min": 1e-4, "max": 0.5, "step": 0.001}),
-                "noise_amplitude": ("FLOAT", {"default": 12.105, "min": 0.0, "max": 1e6, "step": 0.001, "round": 0.001}),
-                "noise_decay_exponent": ("FLOAT", {"default": 0.773, "min": 0.0, "max": 10.0, "step": 0.001, "round": 0.001}),
+                "noise_amplitude": ("FLOAT", {"default": 12.105, "min": 0.0, "max": 1e6, "step": 0.0001, "round": 0.0001}),
+                "noise_decay_exponent": ("FLOAT", {"default": 0.773, "min": 0.0, "max": 10.0, "step": 0.0001, "round": 0.0001}),
                 "seed_offset": ("INT", {"default": 10000, "min": 0, "max": 2**31 - 1}),
             },
         }

--- a/nodes/sampler_node_manual.py
+++ b/nodes/sampler_node_manual.py
@@ -154,8 +154,6 @@ class MiniMaxH3SPEEDSamplerManual:
             transition_mode="explicit",
             noise_policy=noise_policy,
             delta=0.01,
-            noise_amplitude=7.394,
-            noise_decay_exponent=0.62,
             transition_seed_offset=int(seed_offset),
             full_latent_h=full_h,
             full_latent_w=full_w,

--- a/nodes/sampler_sigma_harvest_node.py
+++ b/nodes/sampler_sigma_harvest_node.py
@@ -255,14 +255,14 @@ class MiniMaxH3HarvestToConfig:
 
         # Human-readable report — just the plug-and-play values
         lines = [
-            f"Empirical H3 residual calibration: noise_amplitude={A:.3f}  noise_decay_exponent={beta:.3f}  r²={r2:.4f}  health={health}",
+            f"Empirical H3 residual calibration: noise_amplitude={A:.4f}  noise_decay_exponent={beta:.4f}  r²={r2:.4f}  health={health}",
         ]
         if health in ("suspect", "weak", "invalid"):
             lines.append(
-                f"WARNING: fit is {health.upper()} — beta={beta:.3f} with "
+                f"WARNING: fit is {health.upper()} — beta={beta:.4f} with "
                 f"r²={r2:.4f}. Not cleanly decaying. Rerun harvest or use manual preset."
             )
-        lines.append(f"Paste into SPEED Sampler: Tolerance (Delta)={float(delta):.3f}, noise_amplitude={A:.3f}, noise_decay_exponent={beta:.3f} (transition_mode=delta_custom)")
+        lines.append(f"Paste into SPEED Sampler: Tolerance (Delta)={float(delta):.3f}, noise_amplitude={A:.4f}, noise_decay_exponent={beta:.4f} (transition_mode=delta_custom)")
         # Diagnostic only — not part of the JSON to paste. Shows where delta_custom
         # will place the two most common reference scales for this sigmas length.
         # Derived exactly as runtime does: omega = scale * min(H,W)/2 -> P(omega) -> thr -> first step <= thr.

--- a/speed_scripts/config.py
+++ b/speed_scripts/config.py
@@ -44,9 +44,12 @@ class SpeedConfig:
     transition_seed_offset: int = 10_000
     transition_mode: str = "explicit"  # "explicit" uses transition_steps; "delta_custom" computes from power spectrum
     delta: float = 0.01
-    # Calibrated on H3 0.6MP 40-step harvest (β0.59-0.62, r² fair-good) — 0.6MP sweep stable
-    noise_amplitude: float = 7.394
-    noise_decay_exponent: float = 0.62
+    # Conservative bake from the H3 Sigma-Harvest calibration (Delta 0.005,
+    # A 12.105, beta 0.773, full-res native Euler). The Automatic node always
+    # overrides these explicitly; the defaults exist so a bare SpeedConfig
+    # matches the pack's shipped calibration.
+    noise_amplitude: float = 12.105
+    noise_decay_exponent: float = 0.773
     full_latent_h: int = 45
     full_latent_w: int = 80
     certification: str = "requires_h3_gpu_validation"

--- a/speed_scripts/tests/test_automatic_config.py
+++ b/speed_scripts/tests/test_automatic_config.py
@@ -43,6 +43,11 @@ def test_automatic_node_public_surface_and_defaults():
     assert required["Tolerance (Delta)"][1]["default"] == 0.005
     assert required["noise_amplitude"][1]["default"] == 12.105
     assert required["noise_decay_exponent"][1]["default"] == 0.773
+    assert required["noise_amplitude"][1]["step"] == 0.0001
+    assert required["noise_amplitude"][1]["round"] == 0.0001
+    assert required["noise_decay_exponent"][1]["step"] == 0.0001
+    assert required["noise_decay_exponent"][1]["round"] == 0.0001
+    assert required["Tolerance (Delta)"][1]["step"] == 0.001
 
 
 @pytest.mark.parametrize("stages", [2, 3, 4])
@@ -78,6 +83,16 @@ def test_node_forwards_generation_configuration_to_shared_builder(monkeypatch):
     assert (cfg.delta, cfg.noise_amplitude, cfg.noise_decay_exponent) == (0.007, 13.5, 0.9)
     assert cfg.transition_seed_offset == 777
     assert (cfg.full_latent_h, cfg.full_latent_w) == (45, 80)
+
+    # The widget accepts 4-decimal A/beta (step/round 0.0001); the node must
+    # forward them to the shared builder unrounded.
+    four_digit = _capture_node_config(
+        monkeypatch,
+        noise_amplitude=12.1054,
+        noise_decay_exponent=0.7732,
+    )
+    assert four_digit.noise_amplitude == 12.1054
+    assert four_digit.noise_decay_exponent == 0.7732
 
 
 def test_legacy_aliases_still_resolve(monkeypatch):

--- a/speed_scripts/tests/test_harvest_node.py
+++ b/speed_scripts/tests/test_harvest_node.py
@@ -77,6 +77,16 @@ def test_harvest_runs_one_native_euler_pass_and_emits_calibration():
     assert {"r2", "health", "report"} <= set(calibration)
     assert isinstance(diagnostic, dict) and "samples" in diagnostic
 
+    # Paste line mirrors the Automatic widget's 4-decimal A/beta precision;
+    # delta stays at 3 decimals.
+    paste_line = next(
+        line for line in calibration["report"].splitlines()
+        if line.startswith("Paste into SPEED Sampler:")
+    )
+    assert "noise_amplitude=" + format(calibration["noise_amplitude"], ".4f") in paste_line
+    assert "noise_decay_exponent=" + format(calibration["noise_decay_exponent"], ".4f") in paste_line
+    assert "Tolerance (Delta)=" + format(calibration["delta"], ".3f") in paste_line
+
 
 def test_harvest_reports_no_captures_instead_of_inventing_fit():
     cls = importlib.import_module("sampler_sigma_harvest_node").MiniMaxH3HarvestToConfig

--- a/speed_scripts/tests/test_sampler_node_manual.py
+++ b/speed_scripts/tests/test_sampler_node_manual.py
@@ -33,6 +33,29 @@ def test_manual_node_public_surface():
     assert required["transition_resolution_4"][1]["default"] == 1.0
 
 
+def test_manual_config_stays_explicit_with_inherited_noise_fit(monkeypatch):
+    mod = importlib.import_module("sampler_node_manual")
+    captured = {}
+
+    def fake_pipeline(noise, guider, sigmas, latent_image, config, **kwargs):
+        captured["config"] = config
+        return latent_image, latent_image
+
+    monkeypatch.setattr(mod, "run_speed_pipeline", fake_pipeline)
+    mod.MiniMaxH3SPEEDSamplerManual().sample(
+        make_fake_noise(),
+        make_recording_guider(),
+        torch.linspace(1.0, 0.0, 11),
+        make_latent(h=8, w=8),
+    )
+    cfg = captured["config"]
+    # The runtime reads A/beta only under delta_custom; Manual is explicit,
+    # so its noise fit is inherited from SpeedConfig defaults and is inert.
+    assert cfg.transition_mode == "explicit"
+    assert cfg.delta == 0.01
+    assert (cfg.noise_amplitude, cfg.noise_decay_exponent) == (12.105, 0.773)
+
+
 def test_steps_mode_executes_global_boundaries_and_alignment():
     sigmas = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
     (_out, _denoised), calls, shapes = _run_manual(


### PR DESCRIPTION
## What this changes

The Automatic SPEED sampler's noise-fit widgets now accept four decimal places. `noise_amplitude` and `noise_decay_exponent` on `nodes/sampler_node.py` change `step`/`round` from `0.001` to `0.0001`, so a calibration value like `12.1054` can be typed into the ComfyUI UI instead of being snapped to `12.105`. The `Tolerance (Delta)` widget is untouched.

Two more surfaces now agree with that precision. The Sigma Harvest node's human-readable report (`nodes/sampler_sigma_harvest_node.py`) prints `noise_amplitude` and `noise_decay_exponent` at four decimals in its summary, warning, and "Paste into SPEED Sampler" lines. Delta stays at three decimals, r² stays at four, and the calibration JSON keeps full-precision floats. The `SpeedConfig` dataclass defaults in `speed_scripts/config.py` also move from the stale legacy values `7.394`/`0.62` to the shipped conservative calibration `12.105`/`0.773`, with the comment above them rewritten to describe that bake. The Manual node's explicit `7.394`/`0.62` arguments are removed so it inherits the dataclass defaults.

## Why this change exists

The pack's calibration loop is: run Sigma Harvest, read the fit, paste A/beta into the Automatic node. Both ends only carried three decimals, so a four-decimal fit was truncated at each hop. The old dataclass defaults also described a superseded 0.6MP calibration, which was confusing for anyone building a bare `SpeedConfig`.

## What was deliberately not changed

Numeric defaults stay `12.105`/`0.773` everywhere. README, AGENTS.md, the workflow JSONs, and `evidence/` are untouched — they bake the same numbers, not widget metadata. `speed_scripts/h3_runtime.py` and `speed_scripts/automatic_config.py` are untouched because the passthrough already forwards floats unrounded. Delta handling is untouched.

## Acceptance caveat before merge (frontend)

This repository contains no ComfyUI frontend source, so whether the frontend honors 4-decimal entry and display with `step/round: 0.0001` is unverified here. Before merging, verify in a real ComfyUI:

1. Type `12.1054` into `noise_amplitude` and blur. The widget must keep `12.1054`, not snap to `12.105`. Repeat with `0.7732` on `noise_decay_exponent`.
2. Reload the page. The values must still read `12.1054` / `0.7732`.
3. Save the workflow and reload the saved JSON. The serialized `widgets_values` must hold the exact values.
4. Queue one run. The executed config must keep the 4-decimal values.

If entry or display snaps to 3 decimals, stop and resolve frontend handling before merging — do not ship step/round metadata the frontend silently discards.

## Commits

- 307b994 fix: 4-decimal noise-fit precision on Automatic widget and config defaults
- dba3f39 fix: harvest report pastes noise fit at 4-decimal precision

Each commit has its own comment on the pull request, in this order.

## Verification

`.venv/bin/python -m pytest speed_scripts/tests/ -q` — 55 passed (54 before this change). New coverage pins: widget step/round 0.0001 for A/beta with delta still 0.001; a 4-decimal `12.1054`/`0.7732` pair forwarded through the node to the shared builder with exact equality; Manual's config staying `transition_mode="explicit"` with inherited defaults; and the harvest paste line carrying A/beta at 4 decimals with delta at 3.

## Risks and review focus

Behavior is neutral except for the widget metadata. `speed_scripts/h3_runtime.py` reads A/beta only when `transition_mode == "delta_custom"` — the Automatic node always runs that mode, the Manual node never does — so the Manual node's removed overrides change nothing. The test named `test_manual_config_stays_explicit_with_inherited_noise_fit` pins that. The risk worth your attention is the frontend behavior in the acceptance caveat above.

## Rollback

Revert the two commits. No stored data or external state is affected.
