### PR TITLE
SPEED top-5 samplers (PR A): euler/heun/dpm_2/exp_heun_2_x0 via a run-scoped sampler handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Make MiniMax-H3 video faster without re-training. 
 Starts the denoise at low resolution, then upsamples to full resolution when finetuned detail starts appearing within noise. Allowing us to save on generations.
 
-> **Only Euler, only MiniMax-H3.** Audio is always full-resolution.
+> **MiniMax-H3 only.** Audio is always full-resolution.
 
 ## Installation
 
@@ -49,7 +49,23 @@ You can instead use the following values for base H3:
 
 See the [evidence section](evidence/README.md) for what changes in generation.
 
-Workflow wires are the same for all three: `noise` → `guider` → `sigmas` → `latent_image` → `output_latent` → `VAE Decode`.
+## Supported samplers
+
+SPEED supports exactly four samplers, and the list is intentionally
+restricted: **Euler**, **Heun**, **DPM2** (`dpm_2`), and **Exp Heun 2 X0**
+(`exp_heun_2_x0`). Both the Automatic and Manual nodes expose the same list.
+
+- **Euler** is the reference sampler and the default. SPEED's sigma-harvest
+  calibration and the kappa boundary alignment were derived on Euler.
+- **Heun**, **DPM2**, and **Exp Heun 2 X0** run the same multi-stage SPEED
+  pipeline. They can use extra model evaluations per step (for example
+  Heun's second evaluation), which can reduce the wall-clock gains SPEED
+  buys you.
+- **RES** (`res_multistep`) is not public yet. It keeps step history across
+  stage boundaries and ships only after its state-preservation tests and
+  real validation pass.
+
+Workflow wires are the same for all three nodes: `noise` → `guider` → `sigmas` → `latent_image` → `output_latent` → `VAE Decode`.
 
 ## Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,15 @@ restricted: **Euler**, **Heun**, **DPM2** (`dpm_2`), and **Exp Heun 2 X0**
   pipeline. They can use extra model evaluations per step (for example
   Heun's second evaluation), which can reduce the wall-clock gains SPEED
   buys you.
-- **RES** (`res_multistep`) is not public yet. It keeps step history across
-  stage boundaries and ships only after its state-preservation tests and
-  real validation pass.
+- **RES** (`res_multistep`) is implemented on this branch but **not publicly
+  selectable** — the dropdown still lists exactly the four samplers above.
+  The adapter keeps its step history across SPEED stage boundaries: the
+  previous denoised estimate and its sigma metadata travel with the run, the
+  clean history is projected to each next stage's resolution, and the sigma
+  metadata is rebased at the boundary. It is deterministic and non-ancestral
+  only (no SDE, no CFG++). It stays experimental pending real H3 GPU
+  validation; until that passes, the state-preservation work lives in
+  `speed_scripts/tests/` and the sampler stays out of the public list.
 
 Workflow wires are the same for all three nodes: `noise` → `guider` → `sigmas` → `latent_image` → `output_latent` → `VAE Decode`.
 

--- a/conftest.py
+++ b/conftest.py
@@ -35,7 +35,53 @@ def install_comfy_stubs():
             return list(self._tensors)
 
     nested_tensor.NestedTensor = NestedTensor
+    class KSAMPLER:
+        """Host ``comfy.samplers.KSAMPLER`` contract, minimally modeled.
+
+        Mirrors the real ``KSAMPLER.sample(model_wrap, sigmas, extra_args,
+        callback, noise, latent_image, denoise_mask, disable_pbar)`` shape:
+        injects ``denoise_mask`` into ``extra_args``, wraps the guider in the
+        inpaint-style model callable (whose inner call receives only
+        ``(x, sigma, model_options, seed)`` — the mask blending lives in the
+        wrapper), runs the sampler function, and adapts the per-step dict
+        callback to the native 4-arg callback. Only what SPEED exercises is
+        modeled — no noise_scaling step, because test guiders receive
+        already-processed stage tensors.
+        """
+
+        def __init__(self, sampler_function, extra_options=None):
+            self.sampler_function = sampler_function
+            self.extra_options = extra_options or {}
+
+        def sample(self, model_wrap, sigmas, extra_args, callback, noise,
+                   latent_image=None, denoise_mask=None, disable_pbar=False):
+            extra_args = dict(extra_args)
+            extra_args["denoise_mask"] = denoise_mask
+            model = _InpaintModel(model_wrap)
+            total_steps = len(sigmas) - 1
+
+            def k_callback(entry):
+                if callback is not None:
+                    callback(entry["i"], entry["denoised"], entry["x"], total_steps)
+
+            return self.sampler_function(
+                model, noise, sigmas, extra_args=extra_args,
+                callback=k_callback, disable=disable_pbar,
+                **self.extra_options,
+            )
+
+    class _InpaintModel:
+        """Host ``KSamplerX0Inpaint`` shape: mask in the wrapper, inner call
+        receives ``(x, sigma, model_options, seed)`` only."""
+
+        def __init__(self, inner):
+            self.inner = inner
+
+        def __call__(self, x, sigma, denoise_mask=None, model_options={}, seed=None):
+            return self.inner(x, sigma, model_options=model_options, seed=seed)
+
     samplers.sampler_object = lambda name: ("sampler", name)
+    samplers.KSAMPLER = KSAMPLER
     utils.PROGRESS_BAR_ENABLED = True
 
     class ProgressBar:

--- a/conftest.py
+++ b/conftest.py
@@ -172,6 +172,66 @@ def make_recording_guider(*, sigma_calls=None, callback_every_step=True, stage_s
     return Guider()
 
 
+class RecordingEchoGuider:
+    """Echo guider that records what every stage call received.
+
+    The public output is the stage's noise video plus a fixed offset, so a
+    finished run carries non-trivial signal. Records the sampler object, the
+    sigma schedule, and the noise geometry of each ``sample`` call.
+    """
+
+    class Model:
+        sigma_shift_video = 12.0
+        sigma_shift_audio = 3.0
+
+        def process_latent_out(self, x):
+            return x
+
+    def __init__(self, video_offset=0.0):
+        self.model_patcher = type("P", (), {"model": self.Model()})()
+        self.video_offset = video_offset
+        self.samplers = []
+        self.sigma_calls = []
+        self.noise_shapes = []
+        # Real ComfyUI guiders carry the conditioning dict here; I2V tests
+        # attach a shaped fake (minimax_keyframes / minimax_refs).
+        self.original_conds = None
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        self.sigma_calls.append([float(s) for s in sigmas])
+        pub_video, pub_audio = list(noise.unbind())
+        self.noise_shapes.append(tuple(pub_video.shape))
+        out = make_nested(pub_video + self.video_offset, pub_audio)
+        count = len(sigmas) - 1
+        if callback is not None:
+            for i in range(count):
+                callback(i, out, out, count)
+        return out
+
+
+class SeededRandomNoise:
+    """Noise source returning seeded random noise, so run outputs are
+    non-trivial and determinism is not vacuously true over zero inputs."""
+
+    def __init__(self, seed=42):
+        self.seed = seed
+
+    def generate_noise(self, latent):
+        video, audio = list(latent["samples"].unbind())
+        generator = torch.Generator().manual_seed(self.seed)
+        return make_nested(
+            torch.randn(video.shape, generator=generator),
+            torch.randn(audio.shape, generator=generator),
+        )
+
+
+#: Explicit stage ladders for the 2/3/4-stage completion tests: production
+#: Automatic scale ladders with unique, strictly increasing global boundaries
+#: that tile the 10-interval schedule (5 + 5, 3 + 2 + 5, 2 + 2 + 3 + 3).
+LADDER_BOUNDARIES = {2: (5,), 3: (3, 5), 4: (2, 4, 7)}
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _comfy_stubs():
     install_comfy_stubs()

--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -16,6 +16,7 @@ from speed_scripts.automatic_config import (
     build_automatic_speed_config,
 )
 from speed_scripts.h3_runtime import run_speed_pipeline
+from speed_scripts.sampler_support import SUPPORTED_SPEED_SAMPLERS
 
 
 class MiniMaxH3SPEEDSampler:
@@ -55,13 +56,14 @@ class MiniMaxH3SPEEDSampler:
                 "noise_amplitude": ("FLOAT", {"default": 12.105, "min": 0.0, "max": 1e6, "step": 0.0001, "round": 0.0001}),
                 "noise_decay_exponent": ("FLOAT", {"default": 0.773, "min": 0.0, "max": 10.0, "step": 0.0001, "round": 0.0001}),
                 "seed_offset": ("INT", {"default": 10000, "min": 0, "max": 2**31 - 1}),
+                "sampler_name": (list(SUPPORTED_SPEED_SAMPLERS), {"default": "euler"}),
             },
         }
 
     def sample(self, noise, guider, sigmas, latent_image, stages=3,
                noise_policy="direct_coarse",
                noise_amplitude=12.105, noise_decay_exponent=0.773,
-               seed_offset=10000, **kwargs):
+               seed_offset=10000, sampler_name="euler", **kwargs):
         # Tolerance (Delta) is the UI label — accept delta alias for old workflows/tests
         delta = kwargs.get("Tolerance (Delta)",
                 kwargs.get("Tolerance",
@@ -95,7 +97,7 @@ class MiniMaxH3SPEEDSampler:
             sigmas,
             latent_image,
             config,
-            sampler_name="euler",
+            sampler_name=sampler_name,
             disable_pbar=not comfy.utils.PROGRESS_BAR_ENABLED,
             output_device=None,
         )

--- a/nodes/sampler_node.py
+++ b/nodes/sampler_node.py
@@ -87,14 +87,15 @@ class MiniMaxH3SPEEDSampler:
 
         # The runtime owns the walker lifecycle: it creates (or reuses) the
         # per-run walker, applies every stage, restores full res, and drops
-        # it — including on failure (exception-safe).
+        # it — including on failure (exception-safe). The sampler is built
+        # and closed by the runtime's run-scoped handle.
         return run_speed_pipeline(
             noise,
             guider,
             sigmas,
             latent_image,
             config,
-            sampler=comfy.samplers.sampler_object("euler"),
+            sampler_name="euler",
             disable_pbar=not comfy.utils.PROGRESS_BAR_ENABLED,
             output_device=None,
         )

--- a/nodes/sampler_node_manual.py
+++ b/nodes/sampler_node_manual.py
@@ -17,6 +17,7 @@ import comfy.utils
 from speed_scripts.config import RATIO_MODES, SpeedConfig
 from speed_scripts.h3_runtime import run_speed_pipeline
 from speed_scripts.nodes_common import full_res_dims, validate_transition_steps
+from speed_scripts.sampler_support import SUPPORTED_SPEED_SAMPLERS
 
 
 def CALCULATE_SCALES(transitions, ratio_mode):
@@ -85,6 +86,7 @@ class MiniMaxH3SPEEDSamplerManual:
                     "FLOAT",
                     {"default": 1.0, "min": 0, "max": 1},
                 ),
+                "sampler_name": (list(SUPPORTED_SPEED_SAMPLERS), {"default": "euler"}),
             },
         }
 
@@ -105,6 +107,7 @@ class MiniMaxH3SPEEDSamplerManual:
         transition_resolution_3=0.75,
         transition_goal_4=15,
         transition_resolution_4=1.0,
+        sampler_name="euler",
         **kwargs,
     ):
         transitions = [
@@ -169,7 +172,7 @@ class MiniMaxH3SPEEDSamplerManual:
             sigmas,
             latent_image,
             config,
-            sampler_name="euler",
+            sampler_name=sampler_name,
             disable_pbar=not comfy.utils.PROGRESS_BAR_ENABLED,
             output_device=None,
         )

--- a/nodes/sampler_node_manual.py
+++ b/nodes/sampler_node_manual.py
@@ -161,14 +161,15 @@ class MiniMaxH3SPEEDSamplerManual:
 
         # The runtime owns the walker lifecycle: it creates (or reuses) the
         # per-run walker, applies every stage, restores full res, and drops
-        # it — including on failure (exception-safe).
+        # it — including on failure (exception-safe). The sampler is built
+        # and closed by the runtime's run-scoped handle.
         return run_speed_pipeline(
             noise,
             guider,
             sigmas,
             latent_image,
             config,
-            sampler=comfy.samplers.sampler_object("euler"),
+            sampler_name="euler",
             disable_pbar=not comfy.utils.PROGRESS_BAR_ENABLED,
             output_device=None,
         )

--- a/speed_scripts/h3_runtime.py
+++ b/speed_scripts/h3_runtime.py
@@ -606,7 +606,10 @@ def run_speed_pipeline(
             # the next stage re-enters guider.sample(). Stateless samplers
             # no-op here; stateful samplers (PR B) preserve their step
             # history across the boundary. Never called per denoising step
-            # and never after the final stage.
+            # and never after the final stage. The per-stream shapes let a
+            # stateful handle slice its flat packed history (the real host
+            # packs nested latents before the sampler sees them) back into
+            # video and audio.
             sampler_handle.on_transition(
                 SpeedTransition(
                     stage_idx=stage_idx,
@@ -615,6 +618,10 @@ def run_speed_pipeline(
                     new_sigma=new_q,
                     source_thw=tuple(internal_video.shape[-3:]),
                     target_thw=(next_t, next_h, next_w),
+                    source_stream_shapes=(
+                        tuple(public_video.shape),
+                        tuple(public_audio.shape),
+                    ),
                 )
             )
 

--- a/speed_scripts/h3_runtime.py
+++ b/speed_scripts/h3_runtime.py
@@ -29,12 +29,26 @@ from .spectral import (
 log = logging.getLogger(__name__)
 
 from .latent_class import LatentWalker
+from .sampler_support import (
+    SamplerCapability,
+    SpeedTransition,
+    SpeedSamplerHandle,
+    create_speed_sampler_handle,
+)
 
 
 # Per-pipeline-run walker, stashed on the guider so the same wrapper dict
 # survives every coarse stage and the final restore. Dropped at the end of
 # every run; recreated on the next run that touches the same guider.
 _LW_ATTR = "_speed_latent_walker"
+
+
+class _OverrideSamplerHandle(SpeedSamplerHandle):
+    """Test-seam handle: wraps an injected sampler object as stateless."""
+
+    def __init__(self, sampler):
+        self.sampler = sampler
+        self.capability = SamplerCapability.STATELESS_STEP_LOCAL
 
 
 def _get_or_create_walker(guider) -> LatentWalker:
@@ -291,7 +305,11 @@ def run_speed_pipeline(
     latent: dict,
     config: SpeedConfig,
     *,
-    sampler,
+    sampler_name: str = "euler",
+    # Test/programmatic seam only: injects a fake sampler object without
+    # building a real Comfy sampler. Production node code must never use it;
+    # it may not be combined with a non-default sampler_name.
+    sampler_override=None,
     # PR3 (progress-bar): KEEP THE PROGRESS BAR ON BY DEFAULT. disable_pbar
     # defaults to False (bar VISIBLE). The SPEED sampler node explicitly passes
     # `disable_pbar=not comfy.utils.PROGRESS_BAR_ENABLED` to honor the user's
@@ -302,7 +320,7 @@ def run_speed_pipeline(
     preview_callback=None,
     x0_output=None,
 ):
-    """[Level 1] Run an N-stage progressive-resolution Euler chain (multi-stage SPEED).
+    """[Level 1] Run an N-stage progressive-resolution sampling chain (multi-stage SPEED).
 
     This is intentionally the slow correctness oracle: each public guider call
     performs its own prepare/pre-run/cleanup lifecycle and naturally rebuilds
@@ -311,6 +329,12 @@ def run_speed_pipeline(
     Mirrors canonical SPEED ``generate``: it computes transition steps from
     delta-optimal thresholds, runs each scale stage, and DCT-expands + kappa-aligns
     at each boundary.
+
+    The sampler arrives through a run-scoped ``SpeedSamplerHandle``: built
+    once from ``sampler_name`` (or wrapped from a test-only
+    ``sampler_override``) before the stage loop, notified through
+    ``on_transition()`` once per configured transition, and closed in the
+    run-level cleanup.
 
     Live previews are forwarded from ComfyUI's `latent_preview.prepare_callback`
     pipeline (the same one `SamplerCustomAdvanced` uses). Pass a callback built
@@ -422,6 +446,18 @@ def run_speed_pipeline(
     global_done = 0
     global_start = 0  # GLOBAL index the next stage begins at (into working_sigmas).
 
+    # One run-scoped sampler handle, built before the stage loop. The override
+    # seam wraps a caller-supplied sampler object as a stateless no-op handle;
+    # production paths go through the public sampler_name selector.
+    if sampler_override is not None:
+        if sampler_name != "euler":
+            raise ValueError(
+                "Pass either sampler_name or sampler_override, not both "
+                f"(got sampler_name={sampler_name!r} and sampler_override)."
+            )
+        sampler_handle = _OverrideSamplerHandle(sampler_override)
+    else:
+        sampler_handle = create_speed_sampler_handle(sampler_name)
     # Run-scoped I2V lifecycle: the walker is created up front and EVERY exit
     # path (success, failure in a stage, transition, audio handling, spectral
     # expansion, or final sampling) passes through the finally block, which
@@ -470,7 +506,7 @@ def run_speed_pipeline(
             public = guider.sample(
                 stage_start_pub,
                 stage_start_latent,
-                sampler,
+                sampler_handle.sampler,
                 stage_sigmas,
                 callback=callback,
                 disable_pbar=disable_pbar,
@@ -564,6 +600,24 @@ def run_speed_pipeline(
             else:
                 transitioned_audio = internal_audio
 
+            # Sampler transition hook: once per configured SPEED transition,
+            # after the boundary sigma is aligned and patched into the working
+            # schedule and the spectral + audio transitions are done, before
+            # the next stage re-enters guider.sample(). Stateless samplers
+            # no-op here; stateful samplers (PR B) preserve their step
+            # history across the boundary. Never called per denoising step
+            # and never after the final stage.
+            sampler_handle.on_transition(
+                SpeedTransition(
+                    stage_idx=stage_idx,
+                    ratio=ratio,
+                    old_sigma=rsp_q,
+                    new_sigma=new_q,
+                    source_thw=tuple(internal_video.shape[-3:]),
+                    target_thw=(next_t, next_h, next_w),
+                )
+            )
+
             # Set up re-entry with the aligned boundary + zero latent for the next stage.
             next_noise = pack_latent(
                 reentry_noise(transitioned_video, new_q),
@@ -605,7 +659,7 @@ def run_speed_pipeline(
         final_public = guider.sample(
             stage_start_pub,
             stage_start_latent,
-            sampler,
+            sampler_handle.sampler,
             final_sigmas,
             callback=final_callback,
             disable_pbar=disable_pbar,
@@ -638,7 +692,13 @@ def run_speed_pipeline(
         # or the final sample), restore pristine conditioning latents and
         # remove the walker from the guider. On success apply_final() has
         # already restored + released every wrapper, so this is a no-op.
+        # The sampler handle closes first; its failure must not prevent
+        # walker cleanup, and a failed walker restore must not prevent
+        # dropping the walker from the guider.
         try:
-            walker.apply_final()
+            sampler_handle.close()
         finally:
-            _drop_walker(guider)
+            try:
+                walker.apply_final()
+            finally:
+                _drop_walker(guider)

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -26,6 +26,22 @@ from .flow import aligned_sigma
 from .spectral import spectral_expand_clean_3d
 
 
+def _host_ksampler_class():
+    """The host's real ``KSAMPLER`` class, resolved lazily.
+
+    Importing it at module load would break ComfyUI-free environments (the
+    surrounding package and its tests must import without a full ComfyUI
+    install, which only provides ``comfy.samplers`` at runtime). ``None``
+    means no real host is installed; then only the sampler-function contract
+    is available and the object must not pretend otherwise.
+    """
+    try:
+        from comfy.samplers import KSAMPLER
+    except Exception:
+        return None
+    return KSAMPLER
+
+
 @dataclass
 class ResMultistepState:
     """Step history one RES run carries across SPEED stage boundaries.
@@ -48,26 +64,68 @@ class ResMultistepState:
         self.prev_sigma_in = None
 
 
-def project_clean_history(history, target_thw: tuple[int, int, int]):
+def project_clean_history(history, target_thw: tuple[int, int, int], source_stream_shapes=None):
     """Project one clean RES history to the target video geometry.
 
-    ``history`` is the nested H3 denoised estimate (video ``[B,C,T,H,W]`` +
-    audio ``[B,C,2,T_audio]``) stored as solver history in
+    ``history`` is the clean denoised estimate stored as solver history in
     ``ResMultistepState.old_denoised``. Only the video geometry is projected,
     with :func:`spectral_expand_clean_3d` — the estimate is clean solver
     history, so it never receives fresh high-frequency noise and is never
     scaled by sigma. The clean audio estimate is preserved unchanged and is
     not sigma-reindexed: the boundary sigma belongs to the noisy re-entry
     state, not to this history.
+
+    Two shapes arrive here, depending on where the history was captured:
+
+    * the nested H3 video/audio pair (video ``[B,C,T,H,W]`` + audio
+      ``[B,C,2,T_audio]``) a guider hands back when it executes the sampler
+      directly; or
+    * the flat tensor the real host produces at the sampler boundary. The
+      host ``CFGGuider.sample`` packs nested video+audio with
+      ``comfy.utils.pack_latents`` (each stream reshaped ``[B, 1, -1]``, then
+      concatenated on the last axis) before any sampler code runs, so the
+      model's denoised output — and therefore this history — is a plain
+      ``[B, 1, N]`` tensor. ``source_stream_shapes`` carries the per-stream
+      shapes from that pack; the video slice is the first
+      ``prod(video_shape[1:])`` elements and the audio slice is the rest.
     """
-    if not getattr(history, "is_nested", False):
-        raise ValueError("RES clean history must be a nested H3 video/audio pair")
-    streams = list(history.unbind())
-    if len(streams) != 2:
-        raise ValueError("RES clean history must contain exactly video and audio streams")
-    video, audio = streams
+    if getattr(history, "is_nested", False):
+        streams = list(history.unbind())
+        if len(streams) != 2:
+            raise ValueError("RES clean history must contain exactly video and audio streams")
+        video, audio = streams
+    elif torch.is_tensor(history) and history.ndim == 3:
+        if not source_stream_shapes or len(source_stream_shapes) != 2:
+            raise ValueError(
+                "flat RES clean history needs the host pack's per-stream shapes"
+            )
+        shapes = [tuple(int(d) for d in shape) for shape in source_stream_shapes]
+        if sum(math.prod(s[1:]) for s in shapes) != history.shape[-1]:
+            raise ValueError(
+                "flat RES clean history does not match the recorded stream shapes"
+            )
+        cut = math.prod(shapes[0][1:])
+        video = history[:, :, :cut].reshape(shapes[0])
+        audio = history[:, :, cut:].reshape(shapes[1])
+    else:
+        raise ValueError(
+            "RES clean history must be a nested H3 video/audio pair or the "
+            "host's flat packed tensor"
+        )
     projected_video = spectral_expand_clean_3d(video, target_thw)
-    return type(history)([projected_video, audio])
+    if getattr(history, "is_nested", False):
+        return type(history)([projected_video, audio])
+    # Re-pack in the host pack_latents layout: [B, 1, N] slices concatenated
+    # on the last axis, so the rebased history is exactly the tensor shape
+    # the next host stage produces and consumes.
+    batch = projected_video.shape[0]
+    return torch.cat(
+        (
+            projected_video.reshape(batch, 1, -1),
+            audio.reshape(batch, 1, -1),
+        ),
+        dim=-1,
+    )
 
 
 def rebase_res_history_sigmas(
@@ -113,12 +171,13 @@ def res_multistep_sampler(
 ):
     """Run deterministic RES Multistep over ``sigmas``, carrying ``state``.
 
-    Matches the host ``KSAMPLER`` sampler-function contract: called as
+    Matches the host ``KSAMPLER`` sampler-FUNCTION contract: called as
     ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``
     where ``model(x, sigma, **extra_args)`` returns the denoised estimate
     and ``callback`` receives the native per-step dict. ``disable`` is
     accepted for contract compatibility; this implementation has no progress
-    bar of its own.
+    bar of its own. (The sampler-OBJECT contract is ``.sample`` on
+    :class:`ResMultistepSampler`; the two are not interchangeable.)
     """
     extra_args = {} if extra_args is None else extra_args
     x = noise
@@ -181,21 +240,52 @@ def res_multistep_sampler(
 
 
 class ResMultistepSampler:
-    """Host ``KSAMPLER``-compatible sampler object wrapping the stateful
-    RES function.
+    """Host sampler object wrapping the stateful RES function.
 
-    ``KSAMPLER`` invokes its sampler function as
-    ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``;
-    this object exposes exactly that call shape and always routes through
-    one shared ``ResMultistepState`` so the history survives every SPEED
-    stage call within the run.
+    The host guider invokes a sampler *object* as
+    ``sampler.sample(guider, sigmas, extra_args, callback, noise,
+    latent_image, denoise_mask, disable_pbar)`` (``CFGGuider.inner_sample``
+    wraps ``sampler.sample`` in its wrapper executor), which is the contract
+    native ``KSAMPLER`` objects implement. This class therefore wraps the
+    host's own ``KSAMPLER`` — constructed with :func:`res_multistep_sampler`
+    as its sampler function — and delegates ``.sample`` to it, so
+    ``noise_scaling``, the inpaint model wrapper, the per-step callback
+    adaptation, and ``inverse_noise_scaling`` all stay host-native (plan §13:
+    do not bypass ``guider.sample()``).
+
+    ``__call__`` is the separate sampler-*function* contract: it runs
+    :func:`res_multistep_sampler` directly on already-host-processed inputs,
+    as a plain ``KSAMPLER`` sampler function would receive them. The two
+    contracts are not interchangeable; only ``.sample`` satisfies the host
+    sampler-object seam.
     """
 
     def __init__(self, state: ResMultistepState | None = None):
         self.state = state if state is not None else ResMultistepState()
+        ksampler_cls = _host_ksampler_class()
+        if ksampler_cls is None:
+            raise RuntimeError(
+                "ResMultistepSampler requires the host comfy.samplers.KSAMPLER; "
+                "no real ComfyUI host is available in this environment"
+            )
+        self._ksampler = ksampler_cls(self._run)
 
-    def __call__(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
+    def _run(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
         return res_multistep_sampler(
             model, noise, sigmas, self.state,
+            extra_args=extra_args, callback=callback, disable=disable,
+        )
+
+    def sample(self, model_wrap, sigmas, extra_args, callback, noise,
+               latent_image=None, denoise_mask=None, disable_pbar=False):
+        return self._ksampler.sample(
+            model_wrap, sigmas, extra_args, callback, noise,
+            latent_image=latent_image, denoise_mask=denoise_mask,
+            disable_pbar=disable_pbar,
+        )
+
+    def __call__(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
+        return self._run(
+            model, noise, sigmas,
             extra_args=extra_args, callback=callback, disable=disable,
         )

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -1,0 +1,144 @@
+"""Stateful RES Multistep adapter for the SPEED pipeline.
+
+Deterministic, non-ancestral RES Multistep (``eta=0``): no noise injection,
+no SDE, no CFG++ path. Original implementation written from the published
+RES second-order multistep formulation (exponential integrators in
+``t = -ln(sigma)`` space). ComfyUI is used only as the behavioral reference
+for the host sampler-function contract — its solver source is never copied.
+
+Why this exists: the native ``res_multistep`` sampler keeps its step history
+in function locals, so every SPEED stage call would restart with empty
+history. Worse, the native code derives the previous input sigma from
+``sigmas[i - 1]``, which is the wrong element on the first step of a
+stage-local schedule. This adapter owns that history explicitly in a
+``ResMultistepState`` that the SPEED runtime carries across stages, and
+reads ``t_prev`` from the state instead of the schedule.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class ResMultistepState:
+    """Step history one RES run carries across SPEED stage boundaries.
+
+    ``old_denoised`` is the previous model denoised estimate, ``old_sigma_down``
+    the previous interval's destination sigma, and ``prev_sigma_in`` the
+    previous interval's input sigma. All three are written after every
+    completed interval; a single-sigma stage executes zero intervals and
+    leaves them untouched.
+    """
+
+    old_denoised: object | None = None
+    old_sigma_down: float | None = None
+    prev_sigma_in: float | None = None
+
+    def clear(self) -> None:
+        """Release every history reference (end-of-run cleanup)."""
+        self.old_denoised = None
+        self.old_sigma_down = None
+        self.prev_sigma_in = None
+
+
+def res_multistep_sampler(
+    model,
+    noise,
+    sigmas,
+    state: ResMultistepState,
+    extra_args=None,
+    callback=None,
+    disable=None,
+):
+    """Run deterministic RES Multistep over ``sigmas``, carrying ``state``.
+
+    Matches the host ``KSAMPLER`` sampler-function contract: called as
+    ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``
+    where ``model(x, sigma, **extra_args)`` returns the denoised estimate
+    and ``callback`` receives the native per-step dict. ``disable`` is
+    accepted for contract compatibility; this implementation has no progress
+    bar of its own.
+    """
+    extra_args = {} if extra_args is None else extra_args
+    x = noise
+    s_in = x.new_ones([x.shape[0]]) if torch.is_tensor(x) else 1.0
+
+    for i in range(len(sigmas) - 1):
+        sigma = sigmas[i]
+        denoised = model(x, sigma * s_in, **extra_args)
+        # Deterministic RES (eta=0): the destination sigma is the next
+        # schedule entry and no noise is ever added.
+        sigma_down = sigmas[i + 1]
+        if callback is not None:
+            callback({
+                "x": x, "i": i, "sigma": sigma, "sigma_hat": sigma,
+                "denoised": denoised,
+            })
+
+        sigma_f = float(sigma)
+        sigma_down_f = float(sigma_down)
+        old_denoised = state.old_denoised
+        old_sigma_down = state.old_sigma_down
+        prev_sigma_in = state.prev_sigma_in
+        # First order when the destination sigma is zero, when the carried
+        # history is missing, or when the interval is degenerate (zero width
+        # or a zero previous-step gap, which would divide by zero below).
+        # For every well-formed strictly decreasing schedule this reduces to
+        # the plan rule: first order iff destination sigma is zero or
+        # old_denoised is missing.
+        use_second_order = (
+            0.0 < sigma_down_f < sigma_f
+            and old_denoised is not None
+            and old_sigma_down is not None
+            and prev_sigma_in is not None
+            and old_sigma_down != prev_sigma_in
+        )
+        if use_second_order:
+            # Second order RES multistep: exponential integrators in
+            # t = -ln(sigma) space. t_prev comes from the carried state,
+            # never from sigmas[i - 1]: on the first step of a stage-local
+            # schedule that index is the wrong element.
+            t_old = -math.log(old_sigma_down)
+            t_next = -math.log(sigma_down_f)
+            t_prev = -math.log(prev_sigma_in)
+            h = t_next + math.log(sigma_f)
+            c2 = (t_prev - t_old) / h
+            phi1 = math.expm1(-h) / (-h)
+            phi2 = (phi1 - 1.0) / (-h)
+            b1 = 0.0 if math.isnan(phi1 - phi2 / c2) else phi1 - phi2 / c2
+            b2 = 0.0 if math.isnan(phi2 / c2) else phi2 / c2
+            x = math.exp(-h) * x + h * (b1 * denoised + b2 * old_denoised)
+        else:
+            # First order (Euler).
+            d = (x - denoised) / sigma
+            x = x + d * (sigma_down - sigma)
+
+        state.old_denoised = denoised
+        state.old_sigma_down = sigma_down_f
+        state.prev_sigma_in = sigma_f
+    return x
+
+
+class ResMultistepSampler:
+    """Host ``KSAMPLER``-compatible sampler object wrapping the stateful
+    RES function.
+
+    ``KSAMPLER`` invokes its sampler function as
+    ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``;
+    this object exposes exactly that call shape and always routes through
+    one shared ``ResMultistepState`` so the history survives every SPEED
+    stage call within the run.
+    """
+
+    def __init__(self, state: ResMultistepState | None = None):
+        self.state = state if state is not None else ResMultistepState()
+
+    def __call__(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
+        return res_multistep_sampler(
+            model, noise, sigmas, self.state,
+            extra_args=extra_args, callback=callback, disable=disable,
+        )

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -22,6 +22,9 @@ from dataclasses import dataclass
 
 import torch
 
+from .flow import aligned_sigma
+from .spectral import spectral_expand_clean_3d
+
 
 @dataclass
 class ResMultistepState:
@@ -43,6 +46,60 @@ class ResMultistepState:
         self.old_denoised = None
         self.old_sigma_down = None
         self.prev_sigma_in = None
+
+
+def project_clean_history(history, target_thw: tuple[int, int, int]):
+    """Project one clean RES history to the target video geometry.
+
+    ``history`` is the nested H3 denoised estimate (video ``[B,C,T,H,W]`` +
+    audio ``[B,C,2,T_audio]``) stored as solver history in
+    ``ResMultistepState.old_denoised``. Only the video geometry is projected,
+    with :func:`spectral_expand_clean_3d` — the estimate is clean solver
+    history, so it never receives fresh high-frequency noise and is never
+    scaled by sigma. The clean audio estimate is preserved unchanged and is
+    not sigma-reindexed: the boundary sigma belongs to the noisy re-entry
+    state, not to this history.
+    """
+    if not getattr(history, "is_nested", False):
+        raise ValueError("RES clean history must be a nested H3 video/audio pair")
+    streams = list(history.unbind())
+    if len(streams) != 2:
+        raise ValueError("RES clean history must contain exactly video and audio streams")
+    video, audio = streams
+    projected_video = spectral_expand_clean_3d(video, target_thw)
+    return type(history)([projected_video, audio])
+
+
+def rebase_res_history_sigmas(
+    state: ResMultistepState,
+    new_sigma: float,
+    ratio: float,
+) -> None:
+    """Rebase the sigma-history fields onto the aligned next-stage coordinates.
+
+    The RES history belongs to the old stage's coordinate system, but the next
+    sampler invocation starts at the aligned next-stage boundary. For
+    deterministic RES the previous step destination equals the boundary just
+    left, so ``old_sigma_down`` becomes ``new_sigma``. ``prev_sigma_in`` maps
+    through the same ``aligned_sigma`` scale-coordinate transform the SPEED
+    boundary itself uses. Empty fields stay empty. Mutates ``state`` in place;
+    never touches the scheduler or the working sigma schedule.
+    """
+    if state.old_sigma_down is not None:
+        state.old_sigma_down = float(new_sigma)
+    if state.prev_sigma_in is not None:
+        prev = float(state.prev_sigma_in)
+        if prev >= 1.0:
+            # Deviation from the plan's literal "call aligned_sigma": the
+            # shared transform rejects q >= 1, but an input sigma of 1.0 is
+            # legal history (the first interval of a stage that starts at
+            # pure noise). At q = 1 the transform's own formula gives
+            # kappa = ratio / ratio = 1, i.e. the identity, so the rebased
+            # value stays 1.0. Sigmas above 1 never occur in this repo's
+            # schedules and still fail closed through aligned_sigma.
+            state.prev_sigma_in = prev
+        else:
+            _, state.prev_sigma_in = aligned_sigma(prev, ratio)
 
 
 def res_multistep_sampler(

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -89,14 +89,14 @@ def rebase_res_history_sigmas(
         state.old_sigma_down = float(new_sigma)
     if state.prev_sigma_in is not None:
         prev = float(state.prev_sigma_in)
-        if prev >= 1.0:
+        if prev == 1.0:
             # Deviation from the plan's literal "call aligned_sigma": the
-            # shared transform rejects q >= 1, but an input sigma of 1.0 is
-            # legal history (the first interval of a stage that starts at
-            # pure noise). At q = 1 the transform's own formula gives
+            # shared transform rejects q >= 1, but an input sigma of exactly
+            # 1.0 is legal history (the first interval of a stage that starts
+            # at pure noise). At q = 1 the transform's own formula gives
             # kappa = ratio / ratio = 1, i.e. the identity, so the rebased
-            # value stays 1.0. Sigmas above 1 never occur in this repo's
-            # schedules and still fail closed through aligned_sigma.
+            # value stays 1.0. Every other out-of-domain sigma (> 1 or <= 0)
+            # still fails closed through aligned_sigma.
             state.prev_sigma_in = prev
         else:
             _, state.prev_sigma_in = aligned_sigma(prev, ratio)

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -49,6 +49,12 @@ class SpeedTransition:
     Produced by the stage loop after the boundary sigma has been aligned and
     patched into the working schedule, and handed to the sampler handle's
     transition hook exactly once.
+
+    ``source_stream_shapes`` lists the per-stream latent shapes the stage's
+    sampler saw, in the host's flat-pack order (video first, then audio).
+    Stateless samplers ignore it; the stateful RES handle needs it to slice
+    a flat packed history tensor back into its video and audio streams,
+    because the host packs nested latents flat before any sampler code runs.
     """
 
     stage_idx: int
@@ -57,6 +63,7 @@ class SpeedTransition:
     new_sigma: float
     source_thw: tuple[int, int, int]
     target_thw: tuple[int, int, int]
+    source_stream_shapes: tuple[tuple[int, ...], tuple[int, ...]] | None = None
 
 
 class SpeedSamplerHandle:
@@ -122,11 +129,16 @@ class _ResMultistepSamplerHandle(SpeedSamplerHandle):
             return
         # Clean-history projection: replace the stored video geometry with the
         # clean spectral projection; the clean audio estimate passes through
-        # unchanged. Sigma metadata moves to the aligned next-stage coordinate
+        # unchanged. On the real host path the history is the flat packed
+        # tensor the guider produced at the sampler boundary, so the
+        # per-stream shapes from that pack ride along for the video/audio
+        # split. Sigma metadata moves to the aligned next-stage coordinate
         # system. Coincident boundaries simply run this again on the already
         # projected history; new history is never synthesized here.
         self.state.old_denoised = project_clean_history(
-            self.state.old_denoised, transition.target_thw
+            self.state.old_denoised,
+            transition.target_thw,
+            source_stream_shapes=transition.source_stream_shapes,
         )
         rebase_res_history_sigmas(
             self.state, transition.new_sigma, transition.ratio

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -1,0 +1,108 @@
+"""Sampler-support layer for the SPEED multi-stage pipeline.
+
+The SPEED stage loop in ``h3_runtime`` runs one sampler through several
+progressive-resolution stages. This module owns everything sampler-related
+for that loop:
+
+* the public, curated list of sampler names SPEED supports,
+* a capability classification per sampler,
+* a run-scoped ``SpeedSamplerHandle`` that wraps the sampler object plus any
+  run-scoped state, with a transition hook called once per configured SPEED
+  transition and a ``close()`` for end-of-run cleanup.
+
+The stage loop and scheduler logic never branch on the sampler name; they
+only talk to the handle. All solver math stays inside ComfyUI's native
+sampler objects — this repository never reimplements a solver.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+#: Stateless, step-local samplers exposed by SPEED. Their behavior at a
+#: SPEED stage boundary needs no cross-stage state, so their handle hook is
+#: a no-op.
+STATELESS_SPEED_SAMPLERS = (
+    "euler",
+    "heun",
+    "dpm_2",
+    "exp_heun_2_x0",
+)
+
+#: Public selector list. PR B adds ``res_multistep`` here only after its
+#: state-preservation tests and real H3 validation pass.
+SUPPORTED_SPEED_SAMPLERS = STATELESS_SPEED_SAMPLERS
+
+
+class SamplerCapability(Enum):
+    """What a sampler needs from the SPEED stage loop."""
+
+    #: Pure per-step function; no state survives a stage boundary.
+    STATELESS_STEP_LOCAL = "stateless_step_local"
+    #: Keeps step history across stage boundaries; the handle preserves it.
+    SINGLE_HISTORY = "single_history"
+
+
+@dataclass(frozen=True)
+class SpeedTransition:
+    """One configured SPEED transition boundary.
+
+    Produced by the stage loop after the boundary sigma has been aligned and
+    patched into the working schedule, and handed to the sampler handle's
+    transition hook exactly once.
+    """
+
+    stage_idx: int
+    ratio: float
+    old_sigma: float
+    new_sigma: float
+    source_thw: tuple[int, int, int]
+    target_thw: tuple[int, int, int]
+
+
+class SpeedSamplerHandle:
+    """Run-scoped wrapper around one SPEED sampler choice.
+
+    The stage loop receives this handle from ``run_speed_pipeline`` and never
+    touches the raw sampler name or any sampler state. Stateless samplers
+    need nothing at boundaries, so both methods are no-ops; stateful handles
+    (PR B ``res_multistep``) override them. The handle never mutates the
+    scheduler or the working sigma schedule.
+    """
+
+    sampler: object
+    capability: SamplerCapability
+
+    def on_transition(self, transition: SpeedTransition) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _StatelessSamplerHandle(SpeedSamplerHandle):
+    """Run-scoped handle for a stateless, step-local sampler."""
+
+    def __init__(self, name: str):
+        # Built exactly once per SPEED run, here — never per stage, never
+        # per denoising step. Imported lazily because the surrounding
+        # package must import (and its tests must collect) outside a full
+        # ComfyUI install, which only provides comfy.samplers at runtime.
+        from comfy.samplers import sampler_object
+
+        self.sampler = sampler_object(name)
+        self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+
+def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
+    """Build the run-scoped handle for ``sampler_name``.
+
+    Unknown names raise ``ValueError`` listing the invalid name and the
+    supported names. Never falls back to Euler.
+    """
+    if sampler_name not in SUPPORTED_SPEED_SAMPLERS:
+        supported = ", ".join(repr(name) for name in SUPPORTED_SPEED_SAMPLERS)
+        raise ValueError(
+            f"Unsupported SPEED sampler {sampler_name!r}. "
+            f"Supported samplers: {supported}."
+        )
+    return _StatelessSamplerHandle(sampler_name)

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -110,6 +110,30 @@ class _ResMultistepSamplerHandle(SpeedSamplerHandle):
         self.sampler = ResMultistepSampler(self.state)
         self.capability = SamplerCapability.SINGLE_HISTORY
 
+    def on_transition(self, transition: SpeedTransition) -> None:
+        from .res_multistep_adapter import (
+            project_clean_history,
+            rebase_res_history_sigmas,
+        )
+
+        # No completed RES interval yet: nothing to project or rebase. The
+        # empty state is preserved as-is; no history is created here.
+        if self.state.old_denoised is None:
+            return
+        # Clean-history projection: replace the stored video geometry with the
+        # clean spectral projection; the clean audio estimate passes through
+        # unchanged. Sigma metadata moves to the aligned next-stage coordinate
+        # system. Coincident boundaries simply run this again on the already
+        # projected history; new history is never synthesized here.
+        self.state.old_denoised = project_clean_history(
+            self.state.old_denoised, transition.target_thw
+        )
+        rebase_res_history_sigmas(
+            self.state, transition.new_sigma, transition.ratio
+        )
+        # Deliberately untouched: the scheduler and working sigma schedule,
+        # the noisy re-entry tensors, and all H3 conditioning tensors.
+
     def close(self) -> None:
         self.state.clear()
 
@@ -129,7 +153,7 @@ def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
     return _StatelessSamplerHandle(sampler_name)
 
 
-def create_res_multistep_sampler_handle() -> SpeedSamplerHandle:
+def create_res_multistep_sampler_handle() -> "_ResMultistepSamplerHandle":
     """Build the run-scoped stateful RES handle (runtime-only seam).
 
     Not part of the public selector yet: ``res_multistep`` joins

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -93,6 +93,27 @@ class _StatelessSamplerHandle(SpeedSamplerHandle):
         self.capability = SamplerCapability.STATELESS_STEP_LOCAL
 
 
+class _ResMultistepSamplerHandle(SpeedSamplerHandle):
+    """Run-scoped handle for the stateful RES Multistep adapter.
+
+    Owns one ``ResMultistepState`` per SPEED run. The wrapped sampler
+    object keeps that state across every stage's ``guider.sample()`` call,
+    so RES history survives stage boundaries; ``close()`` (run-level
+    cleanup) releases it. Never routes through the stage-resetting native
+    ``sampler_object("res_multistep")``.
+    """
+
+    def __init__(self):
+        from .res_multistep_adapter import ResMultistepSampler, ResMultistepState
+
+        self.state = ResMultistepState()
+        self.sampler = ResMultistepSampler(self.state)
+        self.capability = SamplerCapability.SINGLE_HISTORY
+
+    def close(self) -> None:
+        self.state.clear()
+
+
 def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
     """Build the run-scoped handle for ``sampler_name``.
 
@@ -106,3 +127,14 @@ def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
             f"Supported samplers: {supported}."
         )
     return _StatelessSamplerHandle(sampler_name)
+
+
+def create_res_multistep_sampler_handle() -> SpeedSamplerHandle:
+    """Build the run-scoped stateful RES handle (runtime-only seam).
+
+    Not part of the public selector yet: ``res_multistep`` joins
+    ``SUPPORTED_SPEED_SAMPLERS`` only after the RES state-preservation
+    tests and real H3 validation pass (plan PR B acceptance). The runtime
+    reaches RES through this factory alone.
+    """
+    return _ResMultistepSamplerHandle()

--- a/speed_scripts/spectral.py
+++ b/speed_scripts/spectral.py
@@ -223,6 +223,42 @@ def spectral_expand_3d(
     return idct_temporal(idct2(dct_full)).to(dtype=original_dtype)
 
 
+def spectral_expand_clean_3d(
+    value: torch.Tensor,           # [..., T_coarse, H_coarse, W_coarse]
+    target_thw: tuple[int, int, int],
+) -> torch.Tensor:
+    """Clean-history 3D spectral projection: deterministic, no noise.
+
+    Input is a clean denoised estimate (solver history), not noisy state, so
+    the target's new high-frequency DCT coefficients are zero — never random.
+    Combined temporal + spatial DCT, zero-filled target coefficient tensor,
+    copy of the source low-frequency block, inverse combined DCT. Deterministic
+    and sigma-free by construction.
+    """
+    target_t, target_h, target_w = (int(target_thw[0]), int(target_thw[1]), int(target_thw[2]))
+    if value.ndim < 3:
+        raise ValueError("spectral_expand_clean_3d expects at least 3 dims")
+    source_t, source_h, source_w = value.shape[-3:]
+    if target_t < source_t or target_h < source_h or target_w < source_w:
+        raise ValueError(
+            f"3D DCT cannot expand {value.shape[-3:]} to {(target_t, target_h, target_w)}"
+        )
+
+    original_dtype = value.dtype
+    # Combined temporal+spatial DCT of the clean source. Same composition as
+    # spectral_expand_3d: the two transforms act on disjoint axes, so the
+    # order is irrelevant.
+    source_dct = dct2(dct_temporal(value))
+    target_dct = torch.zeros(
+        value.shape[:-3] + (target_t, target_h, target_w),
+        device=value.device,
+        dtype=source_dct.dtype,
+    )
+    target_dct[..., :source_t, :source_h, :source_w] = source_dct
+    return idct_temporal(idct2(target_dct)).to(dtype=original_dtype)
+
+
 __all__ = ["dct2", "idct2", "lowpass_dct", "lowpass_filter",
            "spectral_expand", "spectral_expand_coupled",
-           "dct_temporal", "idct_temporal", "spectral_expand_3d"]
+           "dct_temporal", "idct_temporal", "spectral_expand_3d",
+           "spectral_expand_clean_3d"]

--- a/speed_scripts/tests/test_correctness_pass.py
+++ b/speed_scripts/tests/test_correctness_pass.py
@@ -30,7 +30,7 @@ def _run(config, *, guider=None, latent=None, sigmas=SIGMAS):
         sigmas,
         latent if latent is not None else make_latent(),
         config,
-        sampler=object(),
+        sampler_override=object(),
         disable_pbar=True,
     )
 
@@ -117,7 +117,7 @@ def test_coupled_full_grid_projects_full_noise_in_the_spectral_domain():
             SIGMAS,
             make_latent(),
             cfg,
-            sampler=object(),
+            sampler_override=object(),
             disable_pbar=True,
         )
 
@@ -218,7 +218,7 @@ def test_denoised_output_preserves_video_and_audio_streams():
         SIGMAS,
         make_latent(),
         _cfg(),
-        sampler=object(),
+        sampler_override=object(),
         disable_pbar=True,
         x0_output=x0_output,
     )
@@ -365,7 +365,7 @@ def test_audio_transition_oracle_clock_reindex_bridge():
         sigmas,
         make_latent(),
         cfg,
-        sampler=object(),
+        sampler_override=object(),
         disable_pbar=True,
         x0_output=x0_output,
     )

--- a/speed_scripts/tests/test_global_transitions.py
+++ b/speed_scripts/tests/test_global_transitions.py
@@ -34,7 +34,7 @@ def _run(config, sigmas=SIGMAS, latent=None, preview_callback=None):
         sigmas,
         latent or make_latent(),
         config,
-        sampler=object(),
+        sampler_override=object(),
         disable_pbar=True,
         preview_callback=preview_callback,
     )

--- a/speed_scripts/tests/test_node_sampler_compatibility.py
+++ b/speed_scripts/tests/test_node_sampler_compatibility.py
@@ -1,0 +1,206 @@
+"""Public-input compatibility for the sampler_name dropdown (plan §3, §9).
+
+Old workflows have no sampler field: both nodes must execute as Euler, keep
+every pre-existing input in its original position, and append the new
+selector last with a signature default of ``"euler"``.
+"""
+
+import inspect
+import importlib
+
+import torch
+
+from conftest import make_fake_noise, make_latent
+from speed_scripts.sampler_support import SUPPORTED_SPEED_SAMPLERS
+
+
+def _same_latents(a, b):
+    """Compare two latent dicts by tensor value, not object identity."""
+    for part_a, part_b in zip(a["samples"].unbind(), b["samples"].unbind()):
+        if not torch.equal(part_a, part_b):
+            return False
+    return True
+
+
+# The widget order before the dropdown existed. The selector must be appended
+# after it, never inserted between existing widgets.
+AUTOMATIC_INPUT_ORDER_BEFORE = (
+    "noise",
+    "guider",
+    "sigmas",
+    "latent_image",
+    "stages",
+    "noise_policy",
+    "Tolerance (Delta)",
+    "noise_amplitude",
+    "noise_decay_exponent",
+    "seed_offset",
+)
+
+MANUAL_INPUT_ORDER_BEFORE = (
+    "noise",
+    "guider",
+    "sigmas",
+    "latent_image",
+    "noise_policy",
+    "seed_offset",
+    "ratio_mode",
+    "transition_goal_1",
+    "transition_resolution_1",
+    "transition_goal_2",
+    "transition_resolution_2",
+    "transition_goal_3",
+    "transition_resolution_3",
+    "transition_goal_4",
+    "transition_resolution_4",
+)
+
+
+def _node(module_name, class_name):
+    mod = importlib.import_module(module_name)
+    return getattr(mod, class_name)
+
+
+class SamplerRecordingGuider:
+    """Guider that records the native sampler object every stage call uses."""
+
+    class Model:
+        sigma_shift_video = 12.0
+        sigma_shift_audio = 3.0
+
+        def process_latent_out(self, x):
+            return x
+
+    def __init__(self):
+        self.model_patcher = type("P", (), {"model": self.Model()})()
+        self.samplers = []
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        count = len(sigmas) - 1
+        if callback is not None:
+            for i in range(count):
+                callback(i, latent_image, latent_image, count)
+        return latent_image
+
+
+def _automatic_kwargs():
+    return dict(
+        stages=3,
+        noise_amplitude=12.105,
+        noise_decay_exponent=0.773,
+    )
+
+
+def _run_automatic(sigmas, **kwargs):
+    cls = _node("sampler_node", "MiniMaxH3SPEEDSampler")
+    guider = SamplerRecordingGuider()
+    output = cls().sample(
+        make_fake_noise(),
+        guider,
+        sigmas,
+        make_latent(h=8, w=8),
+        **kwargs,
+    )
+    return output, guider.samplers
+
+
+def _run_manual(sigmas, **kwargs):
+    cls = _node("sampler_node_manual", "MiniMaxH3SPEEDSamplerManual")
+    guider = SamplerRecordingGuider()
+    output = cls().sample(
+        make_fake_noise(),
+        guider,
+        sigmas,
+        make_latent(h=8, w=8),
+        transition_goal_1=3, transition_resolution_1=.25,
+        transition_goal_2=5, transition_resolution_2=.5,
+        transition_goal_3=8, transition_resolution_3=.75,
+        transition_goal_4=15, transition_resolution_4=1.0,
+        **kwargs,
+    )
+    return output, guider.samplers
+
+
+def _sigmas():
+    return torch.linspace(1.0, 0.0, 11)
+
+
+# ---------------------------------------------------------------------------
+# Old-workflow payloads: no sampler_name anywhere (plan §3 "Compatibility
+# test", §9 "Old no-name/default path selects Euler")
+# ---------------------------------------------------------------------------
+
+def test_automatic_without_sampler_name_executes_euler():
+    sigmas = _sigmas()
+    no_field, samplers = _run_automatic(sigmas, **_automatic_kwargs())
+    explicit, _ = _run_automatic(
+        sigmas, sampler_name="euler", **_automatic_kwargs()
+    )
+    assert samplers, "run never reached the guider"
+    assert all(sampler == ("sampler", "euler") for sampler in samplers)
+    assert _same_latents(no_field[0], explicit[0])
+
+
+def test_manual_without_sampler_name_executes_euler():
+    sigmas = _sigmas()
+    no_field, samplers = _run_manual(sigmas)
+    explicit, _ = _run_manual(sigmas, sampler_name="euler")
+    assert samplers, "run never reached the guider"
+    assert all(sampler == ("sampler", "euler") for sampler in samplers)
+    assert _same_latents(no_field[0], explicit[0])
+
+
+def test_sample_signatures_default_to_euler():
+    automatic_cls = _node("sampler_node", "MiniMaxH3SPEEDSampler")
+    manual_cls = _node("sampler_node_manual", "MiniMaxH3SPEEDSamplerManual")
+    for cls in (automatic_cls, manual_cls):
+        param = inspect.signature(cls.sample).parameters["sampler_name"]
+        assert param.default == "euler"
+
+
+# ---------------------------------------------------------------------------
+# Widget/input ordering (plan §3: "old widget/input ordering is not changed
+# before the new field")
+# ---------------------------------------------------------------------------
+
+def test_automatic_appends_selector_after_existing_inputs():
+    cls = _node("sampler_node", "MiniMaxH3SPEEDSampler")
+    required = cls.INPUT_TYPES()["required"]
+    keys = tuple(required)
+    assert keys == AUTOMATIC_INPUT_ORDER_BEFORE + ("sampler_name",)
+
+
+def test_manual_appends_selector_after_existing_inputs():
+    cls = _node("sampler_node_manual", "MiniMaxH3SPEEDSamplerManual")
+    required = cls.INPUT_TYPES()["required"]
+    keys = tuple(required)
+    assert keys == MANUAL_INPUT_ORDER_BEFORE + ("sampler_name",)
+
+
+def test_dropdowns_are_exactly_the_supported_names_defaulting_to_euler():
+    automatic_cls = _node("sampler_node", "MiniMaxH3SPEEDSampler")
+    manual_cls = _node("sampler_node_manual", "MiniMaxH3SPEEDSamplerManual")
+    for cls in (automatic_cls, manual_cls):
+        values, options = cls.INPUT_TYPES()["required"]["sampler_name"]
+        assert tuple(values) == tuple(SUPPORTED_SPEED_SAMPLERS)
+        assert options["default"] == "euler"
+
+
+# ---------------------------------------------------------------------------
+# Selector pass-through (plan §3: the dropdown feeds run_speed_pipeline, so a
+# non-default selection must reach the runtime handle unchanged)
+# ---------------------------------------------------------------------------
+
+def test_automatic_passes_non_default_name_to_the_runtime():
+    _out, samplers = _run_automatic(
+        _sigmas(), sampler_name="heun", **_automatic_kwargs()
+    )
+    assert samplers, "run never reached the guider"
+    assert all(sampler == ("sampler", "heun") for sampler in samplers)
+
+
+def test_manual_passes_non_default_name_to_the_runtime():
+    _out, samplers = _run_manual(_sigmas(), sampler_name="heun")
+    assert samplers, "run never reached the guider"
+    assert all(sampler == ("sampler", "heun") for sampler in samplers)

--- a/speed_scripts/tests/test_res_host_seam.py
+++ b/speed_scripts/tests/test_res_host_seam.py
@@ -1,0 +1,340 @@
+"""Host-seam tests for the RES Multistep adapter (plan S7 §13).
+
+These tests exercise the two seams the real ComfyUI host builds and the
+earlier runtime tests bypassed:
+
+1. The sampler-OBJECT contract. The host ``CFGGuider.inner_sample`` wraps
+   ``sampler.sample`` in its wrapper executor and calls
+   ``executor.execute(self, sigmas, extra_args, callback, noise,
+   latent_image, denoise_mask, disable_pbar)`` — the object must expose
+   ``.sample`` with that shape. A guider here invokes the sampler object
+   exactly that way.
+
+2. The flat packed tensor at the sampler boundary. On a real nested-latent
+   H3 run, ``CFGGuider.sample`` packs video+audio FLAT with
+   ``comfy.utils.pack_latents`` (each stream reshaped ``[B, 1, -1]``,
+   concatenated on the last axis) before any sampler code runs, and unpacks
+   the sampler output back into a nested tensor afterwards. So the model's
+   denoised output at the boundary — and therefore the RES history stored in
+   ``ResMultistepState.old_denoised`` — is a plain flat tensor, and the
+   ``on_transition`` history projection must split video from audio without
+   crashing.
+
+The conftest ``KSAMPLER`` stub models the host shape; these tests use it the
+way ``CFGGuider`` uses the real one.
+"""
+
+import math
+
+import pytest
+import torch
+
+import speed_scripts.h3_runtime as h3_runtime
+from conftest import (
+    LADDER_BOUNDARIES,
+    SeededRandomNoise,
+    make_latent,
+)
+from speed_scripts.automatic_config import STAGES_TO_SCALES
+from speed_scripts.config import SpeedConfig
+from speed_scripts.h3_runtime import _LW_ATTR, run_speed_pipeline
+from speed_scripts.res_multistep_adapter import (
+    ResMultistepSampler,
+    ResMultistepState,
+)
+from speed_scripts.sampler_support import (
+    SpeedTransition,
+    create_res_multistep_sampler_handle,
+)
+
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# Host-shaped helpers
+# ---------------------------------------------------------------------------
+
+def _pack_latents(streams):
+    """The host ``comfy.utils.pack_latents`` layout, verbatim."""
+    shapes, tensors = [], []
+    for tensor in streams:
+        shapes.append(tuple(tensor.shape))
+        tensors.append(tensor.reshape(tensor.shape[0], 1, -1))
+    return torch.cat(tensors, dim=-1), shapes
+
+
+def _unpack_latents(combined, shapes):
+    """The host ``comfy.utils.unpack_latents`` layout, verbatim."""
+    out, work = [], combined
+    for shape in shapes:
+        cut = math.prod(shape[1:])
+        out.append(work[:, :, :cut].reshape([work.shape[0]] + list(shape)[1:]))
+        work = work[:, :, cut:]
+    return out
+
+
+class HostShapedGuider:
+    """A guider with the real host CFGGuider calling conventions.
+
+    ``sample`` packs nested noise + latent flat, then invokes the sampler
+    object through the host sampler-object contract: a WrapperExecutor-style
+    ``getattr(sampler, "sample")`` lookup followed by the positional call
+    ``sampler.sample(self, sigmas, extra_args, callback, noise, latent_image,
+    denoise_mask, disable_pbar)``. The model callable is the host's
+    ``KSamplerX0Inpaint`` shape (inner call receives only
+    ``(x, sigma, model_options, seed)``). The sampler output is unpacked back
+    into a nested pair, like ``CFGGuider.sample`` does. Records the sampler
+    objects it saw and the state snapshot at each stage entry.
+
+    Carries ``model_patcher.model`` with the sigma-shift attributes the
+    SPEED runtime resolves from the guider, like the real host guider does.
+    """
+
+    class _Model:
+        sigma_shift_video = 12.0
+        sigma_shift_audio = 3.0
+
+        def process_latent_out(self, x):
+            return x
+
+    def __init__(self):
+        self.model_patcher = type("P", (), {"model": self._Model()})()
+        self.samplers = []
+        self.sigma_calls = []
+        self.stage_entries = []
+        self.model_evals = 0
+        # Per-stream shapes of the most recent stage's nested latent (the
+        # layout the model call must slice, set fresh by every sample() call).
+        self.stream_shapes = [(1, 1, 2, 4, 4), (1, 1, 2, 8)]
+
+    def __call__(self, x, sigma, denoise_mask=None, model_options=None, seed=None):
+        # CFGGuider shape: the guider itself is the model wrapper KSAMPLER
+        # wraps; its call produces the denoised prediction for the flat pack.
+        # The prediction covers the same flat layout, so the video and audio
+        # slices are transformed separately, like the real H3 model does.
+        self.model_evals += 1
+        s = float(sigma)
+        video_elems = math.prod(self.stream_shapes[0][1:])
+        video, audio = x[:, :, :video_elems], x[:, :, video_elems:]
+        video = video * 0.7 + 0.3 * (s / (1.0 + s))
+        audio = audio * 0.8 + 0.02 * (s / (1.0 + s))
+        return torch.cat(
+            (video.reshape(x.shape[0], 1, -1), audio.reshape(x.shape[0], 1, -1)),
+            dim=-1,
+        )
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        self.sigma_calls.append([float(s) for s in sigmas])
+        nested_streams = list(latent_image.unbind())
+        self.stream_shapes = [tuple(t.shape) for t in nested_streams]
+        noise_flat, _ = _pack_latents(list(noise.unbind()))
+        latent_flat, _ = _pack_latents(nested_streams)
+        state = getattr(sampler, "state", None)
+        if state is not None and state.old_denoised is not None:
+            self.stage_entries.append(_FlatSnapshot(state))
+        else:
+            self.stage_entries.append(None)
+        count = len(sigmas) - 1
+
+        def host_callback(step, x0, x, total_steps):
+            if callback is not None:
+                callback(step, x0, x, total_steps)
+
+        # The exact host invocation: sampler.sample(guider, sigmas,
+        # extra_args, callback, noise, latent_image, denoise_mask, pbar).
+        out_flat = sampler.sample(
+            self, sigmas, {}, host_callback, noise_flat,
+            latent_image=latent_flat, denoise_mask=None, disable_pbar=True,
+        )
+        video, audio = _unpack_latents(
+            out_flat, [tuple(t.shape) for t in latent_image.unbind()]
+        )
+        from conftest import make_nested
+        return make_nested(video, audio)
+
+
+class _FlatSnapshot:
+    """What the run-scoped RES state held when one stage began (flat path)."""
+
+    def __init__(self, state):
+        self.old_denoised = state.old_denoised
+        self.old_sigma_down = state.old_sigma_down
+        self.prev_sigma_in = state.prev_sigma_in
+
+
+def _flat_ladder_cfg(stages, **overrides):
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=LADDER_BOUNDARIES[stages],
+        transition_mode="explicit",
+        audio_policy="carry_preserve",
+        **overrides,
+    )
+
+
+def _run_flat_host(cfg, guider, monkeypatch):
+    handle = create_res_multistep_sampler_handle()
+    captured = []
+
+    def factory(name):
+        captured.append((name, handle))
+        return handle
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", factory)
+    out, denoised = run_speed_pipeline(
+        SeededRandomNoise(), guider, SIGMAS, make_latent(), cfg,
+        sampler_name="res_multistep", disable_pbar=True,
+    )
+    assert captured == [("res_multistep", handle)]
+    return handle, out, denoised
+
+
+# ---------------------------------------------------------------------------
+# Critical 1: the host sampler-object contract (.sample)
+# ---------------------------------------------------------------------------
+
+def test_res_sampler_object_exposes_host_sample_contract():
+    """The attribute the host resolves is ``.sample`` (WrapperExecutor wraps
+    ``sampler.sample``), with the host's positional shape."""
+    sampler = ResMultistepSampler()
+    assert hasattr(sampler, "sample")
+    import inspect
+    params = [p for p in inspect.signature(sampler.sample).parameters if p != "self"]
+    assert params == [
+        "model_wrap", "sigmas", "extra_args", "callback", "noise",
+        "latent_image", "denoise_mask", "disable_pbar",
+    ]
+
+
+def test_host_shaped_sample_call_runs_and_preserves_state():
+    """A host-shaped ``.sample`` call runs the real stateful RES function and
+    routes through the same state object a follow-up call sees. The guider
+    doubles as the model callable (``KSamplerX0Inpaint`` wraps the guider's
+    model, which the wrapper invokes with only ``(x, sigma, ...)``)."""
+    sampler = ResMultistepSampler()
+    seen = []
+
+    def model(x, sigma, denoise_mask=None, model_options=None, seed=None):
+        seen.append(sigma)
+        return x * 0.7
+
+    noise_video = torch.randn(1, 1, 2, 4, 4)
+    noise_audio = torch.randn(1, 1, 2, 8)
+    noise_flat, _ = _pack_latents([noise_video, noise_audio])
+    latent_flat, _ = _pack_latents([
+        torch.zeros_like(noise_video), torch.zeros_like(noise_audio)
+    ])
+    out = sampler.sample(
+        model, SIGMAS[:5], {}, None, noise_flat,
+        latent_image=latent_flat, denoise_mask=None, disable_pbar=True,
+    )
+    assert out.shape == noise_flat.shape
+    # Four intervals, each evaluated once, with the denoise_mask contract the
+    # host KSAMPLER injects into extra_args.
+    assert len(seen) == 4
+    # History was written by the run and is the host's flat tensor shape.
+    assert sampler.state.old_denoised is not None
+    assert torch.is_tensor(sampler.state.old_denoised)
+    assert sampler.state.old_denoised.shape == noise_flat.shape
+    assert sampler.state.old_sigma_down == pytest.approx(0.6)
+    assert sampler.state.prev_sigma_in == pytest.approx(0.7)
+    # A second host-shaped call carries the same state forward.
+    out2 = sampler.sample(
+        model, SIGMAS[4:], {}, None, noise_flat,
+        latent_image=latent_flat, denoise_mask=None, disable_pbar=True,
+    )
+    assert out2.shape == out.shape
+    # 4 intervals in the first call, 6 in the second.
+    assert len(seen) == 10
+
+
+def test_res_multistep_state_clear_releases_history():
+    state = ResMultistepState()
+    state.old_denoised = torch.zeros(1, 1, 4)
+    state.old_sigma_down = 0.5
+    state.prev_sigma_in = 0.7
+    state.clear()
+    assert state.old_denoised is None
+    assert state.old_sigma_down is None
+    assert state.prev_sigma_in is None
+
+
+# ---------------------------------------------------------------------------
+# Critical 2: flat packed history at the sampler boundary
+# ---------------------------------------------------------------------------
+
+def test_flat_history_on_transition_projects_video_and_preserves_audio():
+    """A flat packed history (the only shape the real host produces at the
+    sampler boundary) is projected without crashing: video geometry advances,
+    audio elements pass through bit-exact, and the result re-packs flat."""
+    video = torch.arange(16, dtype=torch.float32).reshape(1, 1, 2, 2, 4) / 16
+    audio = torch.arange(8, dtype=torch.float32).reshape(1, 1, 2, 4) / 8
+    flat, shapes = _pack_latents([video, audio])
+    handle = create_res_multistep_sampler_handle()
+    handle.state.old_denoised = flat
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.7
+    handle.on_transition(SpeedTransition(
+        stage_idx=0, ratio=2.0, old_sigma=0.5, new_sigma=0.4,
+        source_thw=(2, 2, 4), target_thw=(2, 4, 8),
+        source_stream_shapes=shapes,
+    ))
+    projected = handle.state.old_denoised
+    assert torch.is_tensor(projected)
+    # Target geometry (1, 1, 2, 4, 8) = 64 video elems + 8 audio elems.
+    assert projected.shape == (1, 1, 72)
+    p_video, p_audio = _unpack_latents(
+        projected, [(1, 1, 2, 4, 8), (1, 1, 2, 4)]
+    )
+    assert tuple(p_video.shape[-3:]) == (2, 4, 8)
+    # Audio is preserved bit-exact through the projection.
+    assert torch.equal(p_audio, audio)
+    # Sigma metadata was rebased onto the aligned coordinates.
+    assert handle.state.old_sigma_down == pytest.approx(0.4)
+
+
+def test_flat_history_on_transition_requires_stream_shapes():
+    """A flat history without the pack's shapes fails closed instead of
+    guessing a slice boundary."""
+    handle = create_res_multistep_sampler_handle()
+    handle.state.old_denoised = torch.zeros(1, 1, 40)
+    with pytest.raises(ValueError, match="per-stream shapes"):
+        handle.on_transition(SpeedTransition(
+            stage_idx=0, ratio=2.0, old_sigma=0.5, new_sigma=0.4,
+            source_thw=(2, 2, 4), target_thw=(2, 4, 4),
+        ))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a CFGGuider-shaped guider through the real runtime
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3))
+def test_runtime_with_cfgguider_shaped_guider_completes(monkeypatch, stages):
+    """Full run with the guider shaped like the real host ``CFGGuider``:
+    nested in the runtime's hands, flat at the sampler boundary, sampler
+    invoked via ``.sample``. Both criticals crashed exactly here before the
+    fix — no ``.sample`` attribute, then ValueError at the first transition."""
+    guider = HostShapedGuider()
+    handle, out, denoised = _run_flat_host(_flat_ladder_cfg(stages), guider, monkeypatch)
+
+    assert len(guider.sigma_calls) == stages
+    assert guider.model_evals == len(SIGMAS) - 1
+    # Every stage received the SAME run-scoped sampler object.
+    assert guider.samplers == [guider.samplers[0]] * stages
+    assert isinstance(guider.samplers[0], ResMultistepSampler)
+    video, audio = out["samples"].unbind()
+    assert tuple(video.shape[-2:]) == (8, 8)
+    assert audio.ndim == 4
+    # Stage entries: stage 0 empty; later stages carry flat packed history.
+    assert guider.stage_entries[0] is None
+    for snap in guider.stage_entries[1:]:
+        assert snap is not None
+        assert torch.is_tensor(snap.old_denoised)
+        assert snap.old_denoised.ndim == 3  # the host's flat pack
+    # Run-level cleanup ran.
+    assert not hasattr(guider, _LW_ATTR)
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None

--- a/speed_scripts/tests/test_res_multistep_adapter.py
+++ b/speed_scripts/tests/test_res_multistep_adapter.py
@@ -1,0 +1,283 @@
+"""RES Multistep adapter: state model, deterministic pipeline, and the
+same-resolution split oracle (plan S7 §11-§15).
+
+The oracle is the gate for this slice: one uninterrupted deterministic RES
+trajectory over a fixed sigma schedule must land exactly where the same
+schedule does when it is split at a valid interior boundary and the
+``ResMultistepState`` is carried across the split. Splitting must change
+nothing numerically. Three targeted mutations of the carried history
+(discarding ``old_denoised``, ``old_sigma_down``, or ``prev_sigma_in`` at
+the split) must each break the match — that is what makes the test sensitive
+to the state the SPEED stage loop has to preserve. The negative control
+pins the other side: clearing the state at the split must produce a
+different trajectory.
+
+Everything here runs against a deterministic fake model on plain float
+schedules — no ComfyUI import is needed below the handle seam.
+"""
+
+import torch
+import pytest
+
+from speed_scripts.res_multistep_adapter import (
+    ResMultistepSampler,
+    ResMultistepState,
+    res_multistep_sampler,
+)
+from speed_scripts.sampler_support import (
+    STATELESS_SPEED_SAMPLERS,
+    SUPPORTED_SPEED_SAMPLERS,
+    SamplerCapability,
+    _ResMultistepSamplerHandle,
+    create_res_multistep_sampler_handle,
+    create_speed_sampler_handle,
+)
+
+#: Fixed strictly decreasing schedule; the trailing zero is the clean point.
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+#: Plan S7 §15: "tight numeric tolerance". The split changes nothing, so the
+#: two runs must agree to float-epsilon level on these small tensors.
+TOLERANCE = 1e-6
+
+#: Interior boundary used by the split oracle: both segments carry real
+#: RES intervals, so the carried history is exercised at the seam.
+SPLIT_INDEX = 4
+
+
+class DeterministicModel:
+    """Smooth, deterministic stand-in for the diffusion model.
+
+    A fixed linear map of ``x`` blended with a sigma-dependent direction:
+    cheap, deterministic, and nonlinear enough that first-order and
+    second-order RES steps disagree numerically (the oracle's mutation
+    sensitivity depends on that disagreement).
+    """
+
+    def __init__(self, channels=3, seed=7):
+        g = torch.Generator().manual_seed(seed)
+        self.a = torch.randn(channels, generator=g).reshape(1, channels, 1, 1)
+        self.b = torch.randn(channels, generator=g).reshape(1, channels, 1, 1)
+
+    def __call__(self, x, sigma, **kwargs):
+        s = float(sigma)
+        return self.a * x + self.b * (s / (1.0 + s))
+
+
+class CallbackLog:
+    """Records the native per-step callback dicts."""
+
+    def __init__(self):
+        self.entries = []
+
+    def __call__(self, entry):
+        self.entries.append(entry)
+
+
+def _run(samplers_args):
+    """Run RES over consecutive schedule segments, one sampler call each.
+
+    ``samplers_args`` is a list of ``(sigmas, state, clear_first)`` tuples.
+    Returns ``(final_x, states, callbacks)``.
+    """
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4, generator=torch.Generator().manual_seed(123))
+    states, callbacks = [], []
+    for sigmas, state, clear_first in samplers_args:
+        if clear_first:
+            state.clear()
+        log = CallbackLog()
+        x = res_multistep_sampler(
+            model, x, sigmas, state, callback=log, disable=True,
+        )
+        states.append(state)
+        callbacks.append(log)
+    return x, states, callbacks
+
+
+def _split_segment(sigmas, start, end):
+    """Slice ``sigmas[start : end]`` as one stage-local segment."""
+    return sigmas[start:end]
+
+
+# ---------------------------------------------------------------------------
+# State object (plan S7 §12)
+# ---------------------------------------------------------------------------
+
+def test_state_starts_empty_and_clear_releases_everything():
+    state = ResMultistepState()
+    assert state.old_denoised is None
+    assert state.old_sigma_down is None
+    assert state.prev_sigma_in is None
+    tensor = torch.zeros(2, 2)
+    state.old_denoised = tensor
+    state.old_sigma_down = 0.5
+    state.prev_sigma_in = 0.9
+    state.clear()
+    assert state.old_denoised is None
+    assert state.old_sigma_down is None
+    assert state.prev_sigma_in is None
+
+
+def test_single_sigma_stage_executes_zero_intervals_and_touches_nothing():
+    """A one-entry schedule has zero intervals: no model call, no callback,
+    no state write, input returned unchanged."""
+    state = ResMultistepState()
+    state.old_denoised = torch.ones(1, 3, 4, 4)
+    state.old_sigma_down = 0.4
+    state.prev_sigma_in = 0.6
+    x = torch.randn(1, 3, 4, 4)
+    model = DeterministicModel()
+    calls = []
+
+    def counting_model(*args, **kwargs):
+        calls.append(1)
+        return model(*args, **kwargs)
+
+    out = res_multistep_sampler(
+        counting_model, x, torch.tensor([0.5]), state, disable=True,
+    )
+    assert calls == []
+    assert out is x
+    assert state.old_denoised is not None
+    assert state.old_sigma_down == pytest.approx(0.4)
+    assert state.prev_sigma_in == pytest.approx(0.6)
+
+
+def test_final_zero_sigma_interval_uses_first_order_and_updates_state():
+    """The last interval lands on sigma 0: it must take the first-order
+    path (no -log(0)) and still update all three history fields."""
+    state = ResMultistepState()
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4)
+    out = res_multistep_sampler(
+        model, x, torch.tensor([0.3, 0.0]), state, disable=True,
+    )
+    assert torch.isfinite(out).all()
+    assert state.old_denoised is not None
+    assert state.old_sigma_down == 0.0
+    assert state.prev_sigma_in == pytest.approx(0.3)
+
+
+def test_sampler_object_shares_one_state_across_calls():
+    """The KSAMPLER-compatible wrapper routes every call through the same
+    state object, so history survives separate invocations."""
+    sampler = ResMultistepSampler()
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4)
+    x = sampler(model, x, SIGMAS[: SPLIT_INDEX + 1], disable=True)
+    state_after_first = (
+        sampler.state.old_sigma_down, sampler.state.prev_sigma_in,
+    )
+    x = sampler(model, x, SIGMAS[SPLIT_INDEX:], disable=True)
+    # Last completed interval of the first segment: 0.7 -> 0.6.
+    assert state_after_first == pytest.approx((0.6, 0.7))
+    assert sampler.state.old_sigma_down == 0.0
+    assert sampler.state.prev_sigma_in == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# Same-resolution split oracle (plan S7 §15)
+# ---------------------------------------------------------------------------
+
+def test_split_with_carried_state_matches_uninterrupted_run():
+    """Split the schedule at an interior boundary and carry the state:
+    the final x and the full history trajectory must match the
+    uninterrupted run within tight tolerance."""
+    full_x, full_states, full_cbs = _run([(SIGMAS, ResMultistepState(), False)])
+
+    state = ResMultistepState()
+    split_x, split_states, split_cbs = _run([
+        (_split_segment(SIGMAS, 0, SPLIT_INDEX + 1), state, False),
+        (_split_segment(SIGMAS, SPLIT_INDEX, len(SIGMAS)), state, False),
+    ])
+
+    assert torch.allclose(full_x, split_x, atol=TOLERANCE, rtol=0.0)
+    # The whole trajectory, not just the endpoint: per-step callback payloads
+    # must line up one-to-one.
+    assert len(full_cbs[0].entries) == len(SIGMAS) - 1
+    assert len(split_cbs[0].entries) + len(split_cbs[1].entries) == len(SIGMAS) - 1
+    for a, b in zip(
+        full_cbs[0].entries,
+        split_cbs[0].entries + split_cbs[1].entries,
+    ):
+        assert torch.allclose(a["x"], b["x"], atol=TOLERANCE, rtol=0.0)
+        assert torch.allclose(a["denoised"], b["denoised"], atol=TOLERANCE, rtol=0.0)
+    # Carried state converges to the same terminal history.
+    assert full_states[0].old_sigma_down == split_states[-1].old_sigma_down
+    assert full_states[0].prev_sigma_in == split_states[-1].prev_sigma_in
+    assert torch.allclose(
+        full_states[0].old_denoised, split_states[-1].old_denoised,
+        atol=TOLERANCE, rtol=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutation sensitivity: each discarded field must break the match
+# ---------------------------------------------------------------------------
+
+def _split_discarding(discard):
+    """Run the split oracle but drop one history field at the split."""
+    state = ResMultistepState()
+    _run([(_split_segment(SIGMAS, 0, SPLIT_INDEX + 1), state, False)])
+    if discard == "old_denoised":
+        state.old_denoised = None
+    elif discard == "old_sigma_down":
+        state.old_sigma_down = None
+    elif discard == "prev_sigma_in":
+        state.prev_sigma_in = None
+    x, _, _ = _run([(_split_segment(SIGMAS, SPLIT_INDEX, len(SIGMAS)), state, False)])
+    return x
+
+
+@pytest.mark.parametrize("field", ["old_denoised", "old_sigma_down", "prev_sigma_in"])
+def test_oracle_fails_when_a_history_field_is_discarded(field):
+    full_x, _, _ = _run([(SIGMAS, ResMultistepState(), False)])
+    mutated_x = _split_discarding(field)
+    assert not torch.allclose(full_x, mutated_x, atol=TOLERANCE, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Negative control (plan S7 §15)
+# ---------------------------------------------------------------------------
+
+def test_clearing_state_at_the_split_produces_a_different_result():
+    full_x, _, _ = _run([(SIGMAS, ResMultistepState(), False)])
+    state = ResMultistepState()
+    reset_x, _, _ = _run([
+        (_split_segment(SIGMAS, 0, SPLIT_INDEX + 1), state, False),
+        (_split_segment(SIGMAS, SPLIT_INDEX, len(SIGMAS)), state, True),
+    ])
+    assert not torch.allclose(full_x, reset_x, atol=TOLERANCE, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Handle seam (plan S7 §5/§13; public selector stays PR A)
+# ---------------------------------------------------------------------------
+
+def test_res_handle_keeps_single_history_and_clears_on_close():
+    handle = create_res_multistep_sampler_handle()
+    assert isinstance(handle, _ResMultistepSamplerHandle)
+    assert handle.capability is SamplerCapability.SINGLE_HISTORY
+    assert isinstance(handle.sampler, ResMultistepSampler)
+    assert handle.state is handle.sampler.state
+    # History actually lands in the run-scoped state.
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4)
+    handle.sampler(model, x, SIGMAS[: SPLIT_INDEX + 1], disable=True)
+    assert handle.state.old_denoised is not None
+    handle.close()
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None
+
+
+def test_public_selector_still_excludes_res_multistep():
+    assert SUPPORTED_SPEED_SAMPLERS == STATELESS_SPEED_SAMPLERS
+    assert "res_multistep" not in SUPPORTED_SPEED_SAMPLERS
+
+
+def test_public_factory_still_rejects_res_multistep_fail_closed():
+    with pytest.raises(ValueError) as excinfo:
+        create_speed_sampler_handle("res_multistep")
+    assert "res_multistep" in str(excinfo.value)

--- a/speed_scripts/tests/test_res_multistep_adapter.py
+++ b/speed_scripts/tests/test_res_multistep_adapter.py
@@ -1,5 +1,6 @@
-"""RES Multistep adapter: state model, deterministic pipeline, and the
-same-resolution split oracle (plan S7 §11-§15).
+"""RES Multistep adapter: state model, deterministic pipeline, the
+same-resolution split oracle (plan S7 §11-§15), and the transition slice
+(clean history projection, sigma rebase, ``on_transition`` — plan S7 §16-§19).
 
 The oracle is the gate for this slice: one uninterrupted deterministic RES
 trajectory over a fixed sigma schedule must land exactly where the same
@@ -12,6 +13,13 @@ to the state the SPEED stage loop has to preserve. The negative control
 pins the other side: clearing the state at the split must produce a
 different trajectory.
 
+The transition oracles pin plan §16-§18: clean history projection adds zero
+high-frequency content and never touches clean audio; sigma metadata is
+rebased onto the aligned next-stage coordinates; coincident boundaries
+re-project and re-rebase without ever creating new history. Each oracle
+computes its expected values independently so it can fail if the property
+breaks.
+
 Everything here runs against a deterministic fake model on plain float
 schedules — no ComfyUI import is needed below the handle seam.
 """
@@ -19,19 +27,24 @@ schedules — no ComfyUI import is needed below the handle seam.
 import torch
 import pytest
 
+from speed_scripts.flow import aligned_sigma
 from speed_scripts.res_multistep_adapter import (
     ResMultistepSampler,
     ResMultistepState,
+    project_clean_history,
+    rebase_res_history_sigmas,
     res_multistep_sampler,
 )
 from speed_scripts.sampler_support import (
     STATELESS_SPEED_SAMPLERS,
     SUPPORTED_SPEED_SAMPLERS,
     SamplerCapability,
+    SpeedTransition,
     _ResMultistepSamplerHandle,
     create_res_multistep_sampler_handle,
     create_speed_sampler_handle,
 )
+from speed_scripts.spectral import dct2, dct_temporal, spectral_expand_clean_3d
 
 #: Fixed strictly decreasing schedule; the trailing zero is the clean point.
 SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
@@ -281,3 +294,214 @@ def test_public_factory_still_rejects_res_multistep_fail_closed():
     with pytest.raises(ValueError) as excinfo:
         create_speed_sampler_handle("res_multistep")
     assert "res_multistep" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Clean projection primitive (plan S7 §16, §31 step 35)
+# ---------------------------------------------------------------------------
+
+class _Nested:
+    """Minimal nested H3 stand-in: video [B,C,T,H,W] + audio [B,C,2,T_audio].
+
+    Mirrors the real ``NestedTensor`` constructor contract — one list of
+    streams — so ``type(history)([video, audio])`` in the adapter rebuilds
+    the same shape.
+    """
+
+    def __init__(self, streams):
+        self.streams = list(streams)
+        self.is_nested = True
+
+    def unbind(self):
+        return list(self.streams)
+
+
+def _known_video(t=2, h=4, w=4, channels=1, batch=1, seed=99):
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(batch, channels, t, h, w, generator=g)
+
+
+def _known_audio(t_audio=6, channels=1, batch=1, seed=123):
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(batch, channels, 2, t_audio, generator=g)
+
+
+def test_clean_projection_copies_low_band_and_zeroes_high_band():
+    """Round-trip property: the target's combined DCT equals the source's
+    block embedded in an all-zero target tensor. Any random high-frequency
+    content or sigma scaling would break this by orders of magnitude."""
+    source = _known_video()
+    source_dct = dct2(dct_temporal(source))
+    target = spectral_expand_clean_3d(source, (3, 6, 6))
+    expected_dct = torch.zeros(1, 1, 3, 6, 6)
+    expected_dct[..., :2, :4, :4] = source_dct
+    assert torch.allclose(
+        dct2(dct_temporal(target)), expected_dct, atol=1e-5, rtol=0.0,
+    )
+
+
+def test_clean_projection_is_deterministic_and_shape_exact():
+    """No randomness anywhere: two calls agree bit-for-bit, and an exact-shape
+    call reconstructs the input (zero-filled new space is empty)."""
+    source = _known_video()
+    first = spectral_expand_clean_3d(source, (3, 6, 6))
+    second = spectral_expand_clean_3d(source, (3, 6, 6))
+    assert torch.equal(first, second)
+    assert first.shape == (1, 1, 3, 6, 6)
+    exact = spectral_expand_clean_3d(source, (2, 4, 4))
+    assert torch.allclose(exact, source, atol=1e-5, rtol=0.0)
+
+
+def test_clean_projection_preserves_dtype_and_rejects_shrinking():
+    source16 = _known_video().to(dtype=torch.float16)
+    out16 = spectral_expand_clean_3d(source16, (3, 6, 6))
+    assert out16.dtype == torch.float16
+    with pytest.raises(ValueError):
+        spectral_expand_clean_3d(_known_video(t=4, h=6, w=6), (2, 4, 4))
+
+
+def test_clean_history_projection_video_moves_audio_untouched():
+    """Nested H3 history: video geometry grows, the clean audio estimate is
+    numerically unchanged and stays a nested video/audio pair."""
+    video, audio = _known_video(), _known_audio()
+    history = _Nested([video, audio])
+    projected = project_clean_history(history, (4, 8, 8))
+    assert getattr(projected, "is_nested", False)
+    p_video, p_audio = projected.unbind()
+    assert p_video.shape == (1, 1, 4, 8, 8)
+    assert p_audio is audio
+    assert not torch.equal(p_video, video)
+    assert torch.allclose(
+        dct2(dct_temporal(p_video))[..., :2, :4, :4],
+        dct2(dct_temporal(video)),
+        atol=1e-5, rtol=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sigma rebase (plan S7 §17, §31 step 38)
+# ---------------------------------------------------------------------------
+
+def test_rebase_sigmas_sets_destination_and_aligns_prev_input():
+    """Independent expected values: old_sigma_down becomes the aligned
+    boundary sigma; prev_sigma_in maps through aligned_sigma with the same
+    ratio. Empty fields stay empty."""
+    state = ResMultistepState(
+        old_sigma_down=0.42, prev_sigma_in=0.68,
+    )
+    new_q = 0.25
+    ratio = 2.0
+    expected_prev = aligned_sigma(0.68, ratio)[1]
+    rebase_res_history_sigmas(state, new_q, ratio)
+    assert state.old_sigma_down == pytest.approx(new_q)
+    assert state.prev_sigma_in == pytest.approx(expected_prev)
+
+    partial = ResMultistepState(old_sigma_down=0.3)
+    rebase_res_history_sigmas(partial, new_q, ratio)
+    assert partial.old_sigma_down == pytest.approx(new_q)
+    assert partial.prev_sigma_in is None
+
+
+def test_rebase_sigmas_keeps_input_sigma_of_one():
+    """History may legitimately hold prev_sigma_in = 1.0 (a stage starting at
+    pure noise). aligned_sigma rejects q >= 1, but its own formula is the
+    identity there, so the rebased value must stay 1.0 instead of raising."""
+    state = ResMultistepState(old_sigma_down=0.5, prev_sigma_in=1.0)
+    rebase_res_history_sigmas(state, 0.25, 2.0)
+    assert state.old_sigma_down == pytest.approx(0.25)
+    assert state.prev_sigma_in == pytest.approx(1.0)
+
+
+def test_rebase_sigmas_never_mutates_scheduler_data():
+    """The rebase is metadata-only: the caller's schedule tensor must come
+    out byte-identical."""
+    schedule = torch.tensor([1.0, 0.9, 0.5, 0.25, 0.0])
+    snapshot = schedule.clone()
+    state = ResMultistepState(old_sigma_down=0.5, prev_sigma_in=0.9)
+    rebase_res_history_sigmas(state, float(schedule[3]), 1.5)
+    assert torch.equal(schedule, snapshot)
+
+
+# ---------------------------------------------------------------------------
+# on_transition handle hook (plan S7 §18, §31 steps 39-41)
+# ---------------------------------------------------------------------------
+
+def _transition(source_thw, target_thw, ratio=2.0, old_sigma=0.5, stage_idx=0):
+    return SpeedTransition(
+        stage_idx=stage_idx,
+        ratio=ratio,
+        old_sigma=old_sigma,
+        new_sigma=aligned_sigma(old_sigma, ratio)[1],
+        source_thw=source_thw,
+        target_thw=target_thw,
+    )
+
+
+def test_on_transition_projects_history_and_rebases_sigmas():
+    handle = create_res_multistep_sampler_handle()
+    video, audio = _known_video(), _known_audio()
+    handle.state.old_denoised = _Nested([video, audio])
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.6
+    transition = _transition((2, 4, 4), (4, 8, 8), ratio=2.0, old_sigma=0.5)
+
+    handle.on_transition(transition)
+
+    projected_video, projected_audio = handle.state.old_denoised.unbind()
+    assert projected_video.shape == (1, 1, 4, 8, 8)
+    assert projected_audio is audio
+    assert handle.state.old_sigma_down == pytest.approx(transition.new_sigma)
+    assert handle.state.prev_sigma_in == pytest.approx(aligned_sigma(0.6, 2.0)[1])
+
+
+def test_on_transition_leaves_empty_state_alone():
+    """No completed RES interval yet: the hook must preserve empty state and
+    create no history."""
+    handle = create_res_multistep_sampler_handle()
+    handle.on_transition(_transition((2, 4, 4), (4, 8, 8)))
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None
+
+
+def test_on_transition_never_touches_reentry_or_conditioning_tensors():
+    """The hook owns history only: noisy re-entry tensors and conditioning
+    tensors must be byte-identical after the call."""
+    reentry = torch.randn(1, 1, 2, 4, 4)
+    conditioning = torch.randn(1, 1, 2, 4, 4)
+    reentry_snapshot = reentry.clone()
+    conditioning_snapshot = conditioning.clone()
+    handle = create_res_multistep_sampler_handle()
+    handle.state.old_denoised = _Nested([_known_video(), _known_audio()])
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.6
+
+    handle.on_transition(_transition((2, 4, 4), (4, 8, 8)))
+
+    assert torch.equal(reentry, reentry_snapshot)
+    assert torch.equal(conditioning, conditioning_snapshot)
+
+
+def test_on_transition_twice_at_coincident_boundary_no_new_history():
+    """Two boundaries at the same scheduler index: the hook runs for both,
+    history is re-projected to the final geometry, sigma metadata reflects
+    both rebases, and no synthetic new old_denoised is created. Resetting to
+    first order (clearing state) would change the next stage's trajectory,
+    so history must survive both hooks."""
+    handle = create_res_multistep_sampler_handle()
+    video, audio = _known_video(), _known_audio()
+    handle.state.old_denoised = _Nested([video, audio])
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.6
+
+    first = _transition((2, 4, 4), (4, 8, 8), ratio=2.0, old_sigma=0.5)
+    second = _transition((4, 8, 8), (4, 8, 8), ratio=1.5, old_sigma=first.new_sigma)
+    handle.on_transition(first)
+    handle.on_transition(second)
+
+    projected_video, projected_audio = handle.state.old_denoised.unbind()
+    assert projected_video.shape == (1, 1, 4, 8, 8)
+    assert projected_audio is audio
+    assert handle.state.old_sigma_down == pytest.approx(second.new_sigma)
+    expected_prev = aligned_sigma(aligned_sigma(0.6, 2.0)[1], 1.5)[1]
+    assert handle.state.prev_sigma_in == pytest.approx(expected_prev)

--- a/speed_scripts/tests/test_res_multistep_adapter.py
+++ b/speed_scripts/tests/test_res_multistep_adapter.py
@@ -352,10 +352,11 @@ def test_clean_projection_is_deterministic_and_shape_exact():
     assert torch.allclose(exact, source, atol=1e-5, rtol=0.0)
 
 
-def test_clean_projection_preserves_dtype_and_rejects_shrinking():
+def test_clean_projection_preserves_dtype_device_and_rejects_shrinking():
     source16 = _known_video().to(dtype=torch.float16)
     out16 = spectral_expand_clean_3d(source16, (3, 6, 6))
     assert out16.dtype == torch.float16
+    assert out16.device.type == source16.device.type
     with pytest.raises(ValueError):
         spectral_expand_clean_3d(_known_video(t=4, h=6, w=6), (2, 4, 4))
 
@@ -413,13 +414,17 @@ def test_rebase_sigmas_keeps_input_sigma_of_one():
 
 
 def test_rebase_sigmas_never_mutates_scheduler_data():
-    """The rebase is metadata-only: the caller's schedule tensor must come
-    out byte-identical."""
-    schedule = torch.tensor([1.0, 0.9, 0.5, 0.25, 0.0])
-    snapshot = schedule.clone()
-    state = ResMultistepState(old_sigma_down=0.5, prev_sigma_in=0.9)
-    rebase_res_history_sigmas(state, float(schedule[3]), 1.5)
-    assert torch.equal(schedule, snapshot)
+    """The rebase is metadata-only. The state's history tensor is aliased into
+    a schedule-like container standing in for scheduler-owned data: if the
+    rebase ever wrote through the tensor it holds, the alias would surface
+    the write and fail the byte-identical check."""
+    schedule_like = {"boundary": torch.tensor([1.0, 0.9, 0.5, 0.25, 0.0])}
+    snapshot = schedule_like["boundary"].clone()
+    state = ResMultistepState(
+        old_sigma_down=0.5, prev_sigma_in=0.9, old_denoised=schedule_like["boundary"],
+    )
+    rebase_res_history_sigmas(state, float(schedule_like["boundary"][3]), 1.5)
+    assert torch.equal(schedule_like["boundary"], snapshot)
 
 
 # ---------------------------------------------------------------------------
@@ -465,14 +470,15 @@ def test_on_transition_leaves_empty_state_alone():
 
 
 def test_on_transition_never_touches_reentry_or_conditioning_tensors():
-    """The hook owns history only: noisy re-entry tensors and conditioning
-    tensors must be byte-identical after the call."""
+    """The hook owns history only. The noisy re-entry and conditioning tensors
+    are aliased into the history itself: any write-through on the stored
+    history would surface in the aliases and fail the byte-identical check."""
     reentry = torch.randn(1, 1, 2, 4, 4)
     conditioning = torch.randn(1, 1, 2, 4, 4)
     reentry_snapshot = reentry.clone()
     conditioning_snapshot = conditioning.clone()
     handle = create_res_multistep_sampler_handle()
-    handle.state.old_denoised = _Nested([_known_video(), _known_audio()])
+    handle.state.old_denoised = _Nested([reentry, conditioning])
     handle.state.old_sigma_down = 0.5
     handle.state.prev_sigma_in = 0.6
 

--- a/speed_scripts/tests/test_res_multistep_runtime.py
+++ b/speed_scripts/tests/test_res_multistep_runtime.py
@@ -495,7 +495,7 @@ def test_failure_during_res_history_projection_clears_res_state(monkeypatch):
     handle, captured = _inject_res_handle(monkeypatch)
     calls = []
 
-    def exploding_project(history, target_thw):
+    def exploding_project(history, target_thw, source_stream_shapes=None):
         calls.append(1)
         raise RuntimeError("history projection exploded")
 

--- a/speed_scripts/tests/test_res_multistep_runtime.py
+++ b/speed_scripts/tests/test_res_multistep_runtime.py
@@ -1,0 +1,653 @@
+"""RES Multistep through the real SPEED runtime (plan S7 §20-§24, §31 steps 42-46).
+
+B1/B2 pinned the adapter and the transition hook in isolation; this module
+runs ``res_multistep`` through ``run_speed_pipeline`` — the real stage loop,
+the real transition call site, and the real cleanup chain — with the §13
+run-scoped handle injected at the runtime's handle factory (the same seam
+the S6 lifecycle tests use; ``res_multistep`` joins the public selector only
+at plan step 50).
+
+The conftest ``NestedTensor`` stub that ``h3_runtime.pack_latent`` builds has
+no tensor operations, so the guider below unwraps stage tensors into an
+arithmetic-capable nested pair before the sampler runs and wraps the result
+back — mirroring the real host nested-tensor contract the adapter is written
+against. The guider executes the sampler object the runtime hands it, so
+every interval runs the real stateful RES adapter and the carried
+``ResMultistepState`` can be inspected at each stage entry.
+"""
+
+import pytest
+import torch
+
+import speed_scripts.h3_runtime as h3_runtime
+import speed_scripts.res_multistep_adapter as res_multistep_adapter
+from conftest import (
+    LADDER_BOUNDARIES,
+    RecordingEchoGuider,
+    SeededRandomNoise,
+    make_latent,
+    make_nested,
+)
+from speed_scripts.automatic_config import STAGES_TO_SCALES
+from speed_scripts.config import SpeedConfig
+from speed_scripts.flow import aligned_sigma
+from speed_scripts.h3_runtime import _LW_ATTR, run_speed_pipeline
+from speed_scripts.res_multistep_adapter import (
+    ResMultistepSampler,
+    project_clean_history,
+)
+from speed_scripts.sampler_support import create_res_multistep_sampler_handle
+
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+
+class ComputedNested:
+    """Arithmetic-capable nested H3 stand-in (video [B,C,T,H,W] + audio).
+
+    Same unbind/is_nested contract as the host nested tensor, plus the
+    tensor operations the RES solver applies to the working state
+    (add/sub/mul/div against floats and 0-dim schedule tensors).
+    """
+
+    is_nested = True
+
+    def __init__(self, streams):
+        self.streams = list(streams)
+
+    def unbind(self):
+        return list(self.streams)
+
+    def _pair(self, other, fn):
+        if isinstance(other, ComputedNested):
+            parts = other.streams
+        else:
+            parts = [other] * len(self.streams)
+        return ComputedNested([fn(a, b) for a, b in zip(self.streams, parts)])
+
+    def __add__(self, other):
+        return self._pair(other, lambda a, b: a + b)
+
+    def __radd__(self, other):
+        return self._pair(other, lambda a, b: b + a)
+
+    def __sub__(self, other):
+        return self._pair(other, lambda a, b: a - b)
+
+    def __rsub__(self, other):
+        return self._pair(other, lambda a, b: b - a)
+
+    def __mul__(self, other):
+        return self._pair(other, lambda a, b: a * b)
+
+    def __rmul__(self, other):
+        return self._pair(other, lambda a, b: b * a)
+
+    def __truediv__(self, other):
+        return self._pair(other, lambda a, b: a / b)
+
+
+class _Snapshot:
+    """What the run-scoped RES state held when one stage began."""
+
+    def __init__(self, state):
+        video, audio = state.old_denoised.unbind()
+        self.video = video
+        self.audio = audio
+        self.old_sigma_down = state.old_sigma_down
+        self.prev_sigma_in = state.prev_sigma_in
+
+
+class ResExecGuider(RecordingEchoGuider):
+    """Echo guider that actually executes the sampler object it receives.
+
+    ``RecordingEchoGuider`` never calls the sampler, so a stateful RES run
+    would look like a no-op. This guider hands the received sampler object
+    (the runtime handle's real ``ResMultistepSampler``) the stage noise and
+    zero latent as arithmetic nested pairs, records one state snapshot per
+    stage entry, counts model evaluations, keeps every denoised estimate the
+    model produced, and wraps the sampler output back into the stub nested
+    container the runtime unpacks.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.model_evals = 0
+        self.model_outputs = []
+        self.stage_entries = []
+
+    def _model(self):
+        guider = self
+
+        class _Model:
+            def __call__(self, x, sigma, **extra):
+                guider.model_evals += 1
+                s = float(sigma)
+                video, audio = x.unbind()
+                denoised = ComputedNested([
+                    video * 0.7 + 0.3 * (s / (1.0 + s)),
+                    audio * 0.8 + 0.02 * (s / (1.0 + s)),
+                ])
+                guider.model_outputs.append(denoised)
+                return denoised
+
+        return _Model()
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        self.sigma_calls.append([float(s) for s in sigmas])
+        pub_video, pub_audio = list(noise.unbind())
+        self.noise_shapes.append(tuple(pub_video.shape))
+        state = getattr(sampler, "state", None)
+        if state is not None and state.old_denoised is not None:
+            self.stage_entries.append(_Snapshot(state))
+        else:
+            self.stage_entries.append(None)
+        x = ComputedNested(list(latent_image.unbind()))
+        run_noise = ComputedNested([pub_video, pub_audio])
+        count = len(sigmas) - 1
+
+        adapted = None
+        if callback is not None:
+            def adapted(entry):
+                # One native per-interval dict -> one legacy 4-arg callback,
+                # the same adaptation every native sampler callback gets.
+                callback(entry["i"], entry["denoised"], entry["x"], count)
+        out = sampler(
+            self._model(), run_noise, sigmas,
+            extra_args=None, callback=adapted, disable=True,
+        )
+        out_video, out_audio = out.unbind()
+        return make_nested(out_video, out_audio)
+
+
+def _inject_res_handle(monkeypatch):
+    """Route the runtime's handle factory to one fresh run-scoped RES handle.
+
+    The §13 seam: the stage loop only ever talks to a ``SpeedSamplerHandle``.
+    Until plan step 50 promotes ``res_multistep`` into the public selector,
+    the tests inject the handle the §13 factory builds — the exact object
+    production will build. The factory records the sampler name each run
+    requests, so every test can prove the runtime actually asked for
+    ``res_multistep`` instead of silently receiving a patched-in handle.
+    Returns ``(handle, captured)``; ``captured`` accumulates one
+    ``(name, handle)`` entry per run built on this patch.
+    """
+    handle = create_res_multistep_sampler_handle()
+    captured = []
+
+    def factory(name):
+        captured.append((name, handle))
+        return handle
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", factory)
+    return handle, captured
+
+
+def _assert_res_seam(captured, handle):
+    """The runtime requested ``res_multistep`` and got this run-scoped handle."""
+    assert captured == [("res_multistep", handle)]
+
+
+def _run_res(cfg, guider, monkeypatch, **kwargs):
+    handle, captured = _inject_res_handle(monkeypatch)
+    out, denoised = run_speed_pipeline(
+        SeededRandomNoise(), guider, SIGMAS, make_latent(), cfg,
+        sampler_name="res_multistep", disable_pbar=True, **kwargs,
+    )
+    _assert_res_seam(captured, handle)  # one run-scoped handle per run
+    return handle, out, denoised
+
+
+def _explicit_ladder_cfg(stages, **overrides):
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=LADDER_BOUNDARIES[stages],
+        transition_mode="explicit",
+        **overrides,
+    )
+
+
+def _automatic_calibrated_cfg(stages):
+    """The Automatic node's delta_custom config: both transitions quantize
+    onto schedule index 1, so the middle stage gets a single-sigma schedule
+    (zero denoising steps) — the legal coincident-boundary case."""
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=tuple(range(1, len(STAGES_TO_SCALES[stages]))),
+        transition_mode="delta_custom",
+        delta=.005,
+        noise_amplitude=12.105,
+        noise_decay_exponent=.773,
+        full_latent_h=8,
+        full_latent_w=8,
+    )
+
+
+def _interval_counts(stages):
+    bounds = LADDER_BOUNDARIES[stages]
+    edges = (0,) + bounds + (len(SIGMAS) - 1,)
+    return [b - a for a, b in zip(edges[:-1], edges[1:])]
+
+
+def _assert_full_res_nested(latent):
+    video, audio = latent["samples"].unbind()
+    assert video.ndim == 5 and audio.ndim == 4
+    assert tuple(video.shape[-2:]) == (8, 8)
+
+
+def _stage_geometry(stages, stage_idx):
+    """(t, h, w) the ladder runs stage ``stage_idx`` at (no temporal scaling)."""
+    scale = STAGES_TO_SCALES[stages][stage_idx]
+    return (2, max(1, round(8 * scale)), max(1, round(8 * scale)))
+
+
+def _assert_res_state_cleared(handle):
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None
+
+
+# ---------------------------------------------------------------------------
+# §20 runtime completion — 2/3/4-stage ladders through the real adapter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_res_stage_ladder_completes_at_full_resolution(monkeypatch, stages):
+    guider = ResExecGuider()
+    handle, out, denoised = _run_res(_explicit_ladder_cfg(stages), guider, monkeypatch)
+
+    assert len(guider.sigma_calls) == stages
+    # Every global denoising interval ran through the real stateful adapter
+    # (one model evaluation per interval).
+    assert guider.model_evals == len(SIGMAS) - 1
+    # Every stage received the SAME run-scoped sampler object.
+    assert guider.samplers == [guider.samplers[0]] * stages
+    assert isinstance(guider.samplers[0], ResMultistepSampler)
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # Walker and RES handle cleanup both succeeded on the success path.
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_res_state_cleared(handle)
+
+
+# ---------------------------------------------------------------------------
+# §22 RES progress — one callback per outer interval
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_res_callback_count_equals_global_denoising_intervals(monkeypatch, stages):
+    seen = []
+    guider = ResExecGuider()
+    _run_res(
+        _explicit_ladder_cfg(stages), guider, monkeypatch,
+        preview_callback=lambda step, x0, x, total: seen.append((step, total)),
+    )
+    # The ladder tiles the 10-interval schedule; RES adds no callbacks of its
+    # own, so the runtime sees exactly one per global interval.
+    assert seen == [(i, 10) for i in range(10)]
+
+
+# ---------------------------------------------------------------------------
+# §20 state transport — configured transitions carried through state,
+# alignment rebase exercised across stage boundaries
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_res_state_is_carried_and_rebased_across_stage_boundaries(monkeypatch, stages):
+    """At every stage boundary k the carried state must hold
+    ``old_sigma_down == new_q`` and ``prev_sigma_in`` equal to the last
+    interval's input sigma mapped through ``aligned_sigma`` with that
+    boundary's ratio, with the video history already projected to the next
+    stage's geometry. All expected values are computed independently from
+    the schedule and the scale ladder."""
+    guider = ResExecGuider()
+    _run_res(_explicit_ladder_cfg(stages), guider, monkeypatch)
+
+    bounds = LADDER_BOUNDARIES[stages]
+    scales = STAGES_TO_SCALES[stages]
+    entries = guider.stage_entries
+    assert entries[0] is None  # a fresh run starts with empty history
+    for k in range(1, stages):
+        boundary = bounds[k - 1]
+        ratio = scales[k] / scales[k - 1]
+        new_q = aligned_sigma(float(SIGMAS[boundary]), ratio)[1]
+        last_input = float(SIGMAS[boundary - 1])
+        snap = entries[k]
+        assert snap is not None
+        assert snap.old_sigma_down == pytest.approx(new_q, rel=1e-6)
+        assert snap.prev_sigma_in == pytest.approx(
+            aligned_sigma(last_input, ratio)[1], rel=1e-6
+        )
+        # History video was projected to the next stage's geometry; the
+        # clean audio estimate kept its shape and is nonzero.
+        assert tuple(snap.video.shape[-3:]) == _stage_geometry(stages, k)
+        assert tuple(snap.audio.shape) == (1, 1, 2, 44)
+        assert snap.audio.abs().sum() > 0
+        # §21: the clean history audio object is the model's own estimate —
+        # passed through the boundary untouched, never clock-reindexed.
+        intervals_before = sum(_interval_counts(stages)[:k])
+        assert snap.audio is guider.model_outputs[intervals_before - 1].unbind()[1]
+
+
+# ---------------------------------------------------------------------------
+# §20 noise policies — direct_coarse and coupled_full_grid
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("noise_policy", ("direct_coarse", "coupled_full_grid"))
+def test_res_runtime_completes_under_noise_policy(monkeypatch, noise_policy):
+    guider = ResExecGuider()
+    handle, out, denoised = _run_res(
+        _explicit_ladder_cfg(2, noise_policy=noise_policy), guider, monkeypatch,
+    )
+
+    assert len(guider.sigma_calls) == 2
+    assert guider.model_evals == len(SIGMAS) - 1
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # The boundary rebase ran under this noise policy too.
+    snap = guider.stage_entries[1]
+    assert snap is not None
+    boundary = LADDER_BOUNDARIES[2][0]  # the (0.5 -> 1.0) ladder's boundary
+    ratio = STAGES_TO_SCALES[2][1] / STAGES_TO_SCALES[2][0]
+    assert snap.old_sigma_down == pytest.approx(
+        aligned_sigma(float(SIGMAS[boundary]), ratio)[1], rel=1e-6
+    )
+    assert snap.prev_sigma_in == pytest.approx(
+        aligned_sigma(float(SIGMAS[boundary - 1]), ratio)[1], rel=1e-6
+    )
+    assert tuple(snap.video.shape[-3:]) == (2, 8, 8)
+    _assert_res_state_cleared(handle)  # run-level cleanup ran
+
+
+def test_res_noise_policies_produce_different_runs(monkeypatch):
+    """The two policies must actually diverge (the coupled policy feeds the
+    full-grid noise projection instead of fresh coarse noise), so passing
+    one for the other cannot hide behind identical outputs."""
+    outs = []
+    for policy in ("direct_coarse", "coupled_full_grid"):
+        guider = ResExecGuider()
+        _, out, _ = _run_res(
+            _explicit_ladder_cfg(2, noise_policy=policy), guider, monkeypatch,
+        )
+        video, _ = out["samples"].unbind()
+        outs.append(video)
+    assert not torch.equal(outs[0], outs[1])
+
+
+# ---------------------------------------------------------------------------
+# §24 RES I2V smoke — walker restore, pristine conds, history separate from
+# conditioning
+# ---------------------------------------------------------------------------
+
+def _i2v_guider(guider_cls=ResExecGuider):
+    """Guider with real I2V-shaped (nonzero) conditioning attached.
+
+    Returns (guider, keyframes, refs, pristine) where pristine holds a clone
+    of every keyframe latent for the restore assertions.
+    """
+    guider = guider_cls()
+    g = torch.Generator().manual_seed(5)
+    keyframes = [
+        {"latent": torch.randn(1, 1, 2, 8, 8, generator=g)} for _ in range(2)
+    ]
+    refs = [{"latent": torch.randn(1, 1, 2, 8, 8, generator=g)} for _ in range(2)]
+    pristine = [kf["latent"].clone() for kf in keyframes]
+    guider.original_conds = {
+        "positive": [{
+            "minimax_keyframes": keyframes,
+            "minimax_refs": refs,
+        }],
+        "negative": [],
+    }
+    return guider, keyframes, refs, pristine
+
+
+def _assert_pristine_conds(keyframes, refs, pristine):
+    for kf, saved in zip(keyframes, pristine):
+        assert torch.equal(kf["latent"], saved)
+    for ref in refs:
+        assert tuple(ref["latent"].shape[-2:]) == (8, 8)
+
+
+def test_res_i2v_smoke_restores_pristine_and_keeps_history_separate(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    _, out, denoised = _run_res(_explicit_ladder_cfg(3), guider, monkeypatch)
+
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # Walker restore: keyframe latents came back to pristine full-res values,
+    # refs were never resized, and no sampler code rebuilt the cond containers.
+    _assert_pristine_conds(keyframes, refs, pristine)
+    assert not hasattr(guider, _LW_ATTR)
+    # §24: RES history projection is separate from I2V conditioning
+    # projection — the final stage entered with projected solver history
+    # that is no conditioning latent.
+    snap = guider.stage_entries[-1]
+    assert snap is not None
+    assert snap.video.abs().sum() > 0
+    for holder in keyframes + refs:
+        assert snap.video is not holder["latent"]
+        assert not torch.equal(snap.video, holder["latent"])
+
+
+# ---------------------------------------------------------------------------
+# §20 failure/cleanup — every failure point clears RES state, closes the
+# handle, and still runs the walker cleanup through the nested finally chain
+# ---------------------------------------------------------------------------
+
+class ExplodingAtStage2(ResExecGuider):
+    """Fails inside the third guider.sample call (the final stage)."""
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        if len(self.sigma_calls) == 2:
+            raise RuntimeError("sampler call exploded")
+        return super().sample(
+            noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+        )
+
+
+def test_failure_during_sampler_call_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider(ExplodingAtStage2)
+    handle, captured = _inject_res_handle(monkeypatch)
+    with pytest.raises(RuntimeError, match="sampler call exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(3),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    # Two stages had run: RES history existed mid-run, so the cleared state
+    # below proves the close, not an empty run.
+    assert len(guider.stage_entries) == 2
+    assert guider.stage_entries[1] is not None
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+def test_failure_during_spectral_transition_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    handle, captured = _inject_res_handle(monkeypatch)
+    observed = {}
+
+    def exploding_expand(value, target_hw, sigma, seed):
+        # Observed at the moment of explosion: stage 0 had completed real
+        # intervals, so solver history existed when the transition failed.
+        observed["history_existed"] = handle.state.old_denoised is not None
+        raise RuntimeError("spectral transition exploded")
+
+    monkeypatch.setattr(h3_runtime, "spectral_expand", exploding_expand)
+    with pytest.raises(RuntimeError, match="spectral transition exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(2),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    assert observed["history_existed"] is True
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+def test_failure_during_res_history_projection_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    handle, captured = _inject_res_handle(monkeypatch)
+    calls = []
+
+    def exploding_project(history, target_thw):
+        calls.append(1)
+        raise RuntimeError("history projection exploded")
+
+    monkeypatch.setattr(
+        res_multistep_adapter, "project_clean_history", exploding_project
+    )
+    with pytest.raises(RuntimeError, match="history projection exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(2),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    # The hook only calls the projection when history exists, so the call
+    # itself proves stage-0 history existed when the projection failed.
+    assert calls == [1]
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+def test_failure_during_audio_transition_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    handle, captured = _inject_res_handle(monkeypatch)
+    observed = {}
+
+    def exploding_reindex(*args, **kwargs):
+        # Observed at the moment of explosion: history existed when the
+        # audio handling failed (same first boundary as the spectral case).
+        observed["history_existed"] = handle.state.old_denoised is not None
+        raise RuntimeError("audio transition exploded")
+
+    monkeypatch.setattr(h3_runtime, "clock_reindex_audio_state", exploding_reindex)
+    with pytest.raises(RuntimeError, match="audio transition exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(2),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    assert observed["history_existed"] is True
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+# ---------------------------------------------------------------------------
+# §20 state-leak — a fresh RES run after a completed RES run starts clean
+# ---------------------------------------------------------------------------
+
+def test_res_second_generation_after_completed_run_starts_clean(monkeypatch):
+    cfg = _explicit_ladder_cfg(3)
+    guider = ResExecGuider()
+
+    handle_1, out_1, _ = _run_res(cfg, guider, monkeypatch)
+    _assert_res_state_cleared(handle_1)
+
+    handle_2, out_2, _ = _run_res(cfg, guider, monkeypatch)
+    # Same guider object, but a brand-new run-scoped handle: state is never
+    # reused between queue executions.
+    assert handle_2 is not handle_1
+    # The second generation's first stage started from empty history —
+    # nothing leaked from the completed first run.
+    assert guider.stage_entries[3] is None
+    # ... and the whole second trajectory is identical to the first
+    # (deterministic engine, no carried-over corruption).
+    video_1, audio_1 = out_1["samples"].unbind()
+    video_2, audio_2 = out_2["samples"].unbind()
+    assert torch.equal(video_1, video_2)
+    assert torch.equal(audio_1, audio_2)
+
+    # Control: a fresh guider produces the same output bit-for-bit.
+    control = ResExecGuider()
+    _, out_control, _ = _run_res(cfg, control, monkeypatch)
+    video_c, audio_c = out_control["samples"].unbind()
+    assert torch.equal(video_2, video_c)
+    assert torch.equal(audio_2, audio_c)
+    assert not hasattr(guider, _LW_ATTR)
+
+
+# ---------------------------------------------------------------------------
+# §23 zero-step torture — coincident boundaries through the real runtime
+# ---------------------------------------------------------------------------
+
+def test_res_coincident_boundary_zero_step_stages_preserve_history(monkeypatch):
+    """Both transitions quantize onto schedule index 1: stage 1 runs zero
+    denoising steps. The zero-step stage must not update solver history, the
+    transition hooks must still project/rebase it (twice, without corruption),
+    and the final stage must enter with valid history so it can resume
+    second-order behavior."""
+    guider = ResExecGuider()
+    _, out, _ = _run_res(_automatic_calibrated_cfg(3), guider, monkeypatch)
+
+    assert len(guider.sigma_calls) == 3
+    assert len(guider.sigma_calls[1]) == 1  # zero-step middle stage
+    # Model ran 1 + 0 + 9 intervals: the zero-step stage added no history.
+    assert guider.model_evals == len(SIGMAS) - 1
+
+    first = guider.model_outputs[0]
+    entries = guider.stage_entries
+    # Hook 1 projected stage-0 history to stage 1's geometry and rebased
+    # both sigma fields (prev_sigma_in == 1.0 stays 1.0 — legal history).
+    snap1 = entries[1]
+    assert snap1 is not None
+    assert tuple(snap1.video.shape[-3:]) == _stage_geometry(3, 1)
+    assert snap1.old_sigma_down == pytest.approx(
+        aligned_sigma(float(SIGMAS[1]), 2.0)[1], rel=1e-6
+    )
+    assert snap1.prev_sigma_in == pytest.approx(1.0)
+
+    # Hook 2 ran on the unchanged history (zero intervals in between):
+    # the result equals the independent double projection, and the clean
+    # audio estimate is still the very same tensor the model produced.
+    snap2 = entries[2]
+    expected = project_clean_history(
+        project_clean_history(first, _stage_geometry(3, 1)),
+        _stage_geometry(3, 2),
+    )
+    expected_video = expected.unbind()[0]
+    assert torch.equal(snap2.video, expected_video)
+    assert snap2.audio is first.unbind()[1]
+    assert snap2.audio.abs().sum() > 0
+    # Sigma metadata reflects both rebases.
+    chained = aligned_sigma(float(SIGMAS[1]), 2.0)[1]
+    assert snap2.old_sigma_down == pytest.approx(
+        aligned_sigma(chained, 1.5)[1], rel=1e-6
+    )
+    assert snap2.prev_sigma_in == pytest.approx(1.0)
+    # Valid history at the final stage: second-order RES can resume.
+    assert snap2.old_sigma_down != pytest.approx(snap2.prev_sigma_in)
+    _assert_full_res_nested(out)
+    assert not hasattr(guider, _LW_ATTR)
+
+
+def test_res_final_stage_second_order_behavior_depends_on_carried_history(monkeypatch):
+    """The §23 precondition alone (history differs from the input sigma) is
+    not proof: with carried history the final stage's intervals must follow
+    a different trajectory than the documented §15/§28 test-only reset
+    control — history cleared at the boundary, through the real runtime.
+    A run that silently reset history at the boundary would match the
+    control and fail this test."""
+    cfg = _explicit_ladder_cfg(2)
+
+    class ResetAtBoundary(ResExecGuider):
+        def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+            if len(self.sigma_calls) == 1:  # the final stage call
+                sampler.state.clear()  # test-only reset-history control
+            return super().sample(
+                noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+            )
+
+    _, out_carried, _ = _run_res(cfg, ResExecGuider(), monkeypatch)
+    handle_reset, out_reset, _ = _run_res(cfg, ResetAtBoundary(), monkeypatch)
+    assert handle_reset.state.old_denoised is None
+    assert not torch.equal(out_carried["samples"].unbind()[0], out_reset["samples"].unbind()[0])

--- a/speed_scripts/tests/test_sampler_support.py
+++ b/speed_scripts/tests/test_sampler_support.py
@@ -689,7 +689,6 @@ def _i2v_guider():
     return guider, keyframes, refs, guider.original_conds
 
 
-
 @pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
 def test_i2v_smoke_and_pristine_restore_on_success(sampler):
     guider, keyframes, refs, original_conds = _i2v_guider()
@@ -712,7 +711,6 @@ def test_i2v_smoke_and_pristine_restore_on_success(sampler):
     assert cond["minimax_keyframes"] is keyframes
     assert cond["minimax_refs"] is refs
     assert not hasattr(guider, _LW_ATTR)
-
 
 
 @pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)

--- a/speed_scripts/tests/test_sampler_support.py
+++ b/speed_scripts/tests/test_sampler_support.py
@@ -1,5 +1,9 @@
 """Sampler-support contracts: public selector, run-scoped handle lifecycle,
-and Euler regression through the new handle layer.
+Euler regression through the new handle layer, and the S6 suite-level gates
+that are not tied to one sampler: both noise policies on every public
+sampler, the global progress/preview timeline, the coincident-boundary
+Turbo torture ladder, the I2V conditioning matrix, and failure cleanup with
+a clean second generation.
 
 The selector tests pin the fail-closed public surface. The Euler regression
 tests replay the same fake-model run the pre-handle suite used and assert the
@@ -17,8 +21,16 @@ is covered separately.
 import pytest
 import torch
 
-from conftest import make_fake_noise, make_latent, make_recording_guider
+from conftest import (
+    LADDER_BOUNDARIES,
+    RecordingEchoGuider,
+    SeededRandomNoise,
+    make_fake_noise,
+    make_latent,
+    make_recording_guider,
+)
 from speed_scripts import h3_runtime
+from speed_scripts.automatic_config import STAGES_TO_SCALES
 from speed_scripts.config import SpeedConfig
 from speed_scripts.flow import aligned_sigma
 from speed_scripts.h3_runtime import _LW_ATTR, run_speed_pipeline
@@ -39,6 +51,48 @@ def _cfg(**kwargs):
     kwargs.setdefault("scales", (.33, .66, 1.0))
     kwargs.setdefault("transition_steps", (3, 5))
     return SpeedConfig(transition_mode="explicit", **kwargs)
+
+
+def _explicit_ladder_cfg(stages):
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=LADDER_BOUNDARIES[stages],
+        transition_mode="explicit",
+    )
+
+
+def _automatic_calibrated_cfg(stages):
+    """The Automatic node's delta_custom config for ``stages`` stages.
+
+    With the baked calibration constants on the 10-interval schedule every
+    transition quantizes onto schedule index 1, so the middle stages get a
+    single-sigma schedule (zero denoising steps) — the legal
+    coincident-boundary case the runtime must support.
+    """
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=tuple(range(1, len(STAGES_TO_SCALES[stages]))),
+        transition_mode="delta_custom",
+        delta=.005,
+        noise_amplitude=12.105,
+        noise_decay_exponent=.773,
+        full_latent_h=8,
+        full_latent_w=8,
+    )
+
+
+def _run(sampler, cfg, guider, **kwargs):
+    return run_speed_pipeline(
+        SeededRandomNoise(), guider, SIGMAS, make_latent(), cfg,
+        sampler_name=sampler, disable_pbar=True, **kwargs,
+    )
+
+
+def _assert_full_res_nested(latent):
+    """Both H3 streams survived: 5-dim video + 4-dim audio at full 8x8."""
+    video, audio = latent["samples"].unbind()
+    assert video.ndim == 5 and audio.ndim == 4
+    assert tuple(video.shape[-2:]) == (8, 8)
 
 
 def _nested(video, audio):
@@ -505,3 +559,277 @@ def test_run_rejects_unsupported_sampler_name_fail_closed():
     assert "dpmpp_2m" in message
     for supported in SUPPORTED_SPEED_SAMPLERS:
         assert supported in message
+
+
+# ---------------------------------------------------------------------------
+# S6: Noise policies (source §9 remainder) — both policies smoke on every
+# public sampler through the real selector path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_noise_policy_direct_coarse_smoke_per_sampler(sampler):
+    guider = RecordingEchoGuider(video_offset=.5)
+    out, denoised = _run(sampler, _explicit_ladder_cfg(3), guider)
+    assert len(guider.noise_shapes) == 3
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_noise_policy_coupled_full_grid_smoke_per_sampler(sampler):
+    cfg = _cfg(noise_policy="coupled_full_grid")
+    guider = RecordingEchoGuider(video_offset=.5)
+    out, denoised = _run(sampler, cfg, guider)
+    assert len(guider.noise_shapes) == 3
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+
+
+# ---------------------------------------------------------------------------
+# S6: Progress / preview (source §22, PR A scope) — the public timeline is
+# one continuous 0..total denoising pass for every sampler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_public_progress_is_monotonic_across_stages(sampler):
+    """Callback indices rise on one global timeline: no per-stage restart,
+    and each stage's local steps continue where the previous stage stopped."""
+    seen = []
+    guider = RecordingEchoGuider(video_offset=.5)
+    _run(
+        sampler, _explicit_ladder_cfg(3), guider,
+        preview_callback=lambda step, x0, x, total: seen.append(step),
+    )
+    assert seen == list(range(10))
+
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_shared_x0_output_and_final_denoised_are_valid_nested_h3(sampler):
+    """The shared x0 dict stays valid across stages and the denoised output
+    keeps the full nested H3 video+audio structure at full resolution."""
+    x0_output = {}
+    guider = RecordingEchoGuider(video_offset=.5)
+    _out, denoised = _run(
+        sampler, _explicit_ladder_cfg(3), guider, x0_output=x0_output,
+    )
+    assert "x0" in x0_output
+    _assert_full_res_nested(denoised)
+    _assert_full_res_nested({"samples": x0_output["x0"]})
+
+
+# ---------------------------------------------------------------------------
+# S6: Zero-step / 8-step Turbo torture (source §23, all public samplers) —
+# the coincident-boundary ladder still runs every configured transition and
+# alignment, and progress stays monotonic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_turbo_coincident_ladder_runs_every_transition_and_alignment(sampler):
+    """Short-schedule torture case (the plan's Turbo torture block): with
+    the baked calibration every transition quantizes onto one boundary, each
+    middle stage gets a single-sigma slice (zero denoising steps), and the
+    spectral expand + kappa alignment still patched the schedule (re-entry
+    sigma is the aligned coordinate, not the raw schedule value)."""
+    cfg = _automatic_calibrated_cfg(3)
+    guider = RecordingEchoGuider()
+    seen = []
+    out, _ = _run(
+        sampler, cfg, guider,
+        preview_callback=lambda step, x0, x, total: seen.append(step),
+    )
+
+    assert len(guider.sigma_calls) == 3
+    for call in guider.sigma_calls[1:-1]:
+        assert len(call) == 1  # single-sigma slice: no crash, zero steps
+    # Every configured spectral transition executed: all three stages ran
+    # through the selected native sampler object.
+    assert guider.samplers == [("sampler", sampler)] * 3
+    # Every configured sigma alignment executed: both transitions quantized
+    # onto the same boundary coordinate, and each re-aligned it with its own
+    # stage ratio (0.333→0.667 is ratio 2.0, 0.667→1.0 is ratio 1.5) — the
+    # documented coincident-boundary model.
+    first_kappa, first_aligned = aligned_sigma(float(SIGMAS[1]), 2.0)
+    second_kappa, second_aligned = aligned_sigma(first_aligned, 1.5)
+    assert guider.sigma_calls[1][0] == pytest.approx(first_aligned)
+    assert guider.sigma_calls[2][0] == pytest.approx(second_aligned)
+    # Progress stayed monotonic across the whole coincident ladder.
+    assert seen == list(range(10))
+    _assert_full_res_nested(out)
+
+
+# ---------------------------------------------------------------------------
+# S6: I2V matrix (source §24, PR A scope) — keyframe/ref latents follow the
+# LatentWalker lifecycle per sampler, pristine conditioning is restored on
+# success and failure, and no sampler code mutates guider.original_conds
+# structurally
+# ---------------------------------------------------------------------------
+
+def _i2v_guider():
+    """RecordingEchoGuider with real I2V-shaped conditioning attached.
+
+    Returns (guider, keyframes, refs, original_conds) where keyframes/refs
+    are the live holder dicts the walker resizes and original_conds is the
+    container object the guider owns.
+    """
+    guider = RecordingEchoGuider(video_offset=.5)
+    keyframes = [{"latent": torch.zeros(1, 1, 2, 8, 8)} for _ in range(2)]
+    refs = [{"latent": torch.zeros(1, 1, 2, 8, 8)} for _ in range(2)]
+    guider.original_conds = {
+        "positive": [{
+            "minimax_keyframes": keyframes,
+            "minimax_refs": refs,
+        }],
+        "negative": [],
+    }
+    return guider, keyframes, refs, guider.original_conds
+
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_i2v_smoke_and_pristine_restore_on_success(sampler):
+    guider, keyframes, refs, original_conds = _i2v_guider()
+    out, denoised = _run(sampler, _explicit_ladder_cfg(3), guider)
+
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # Keyframe latents followed the LatentWalker: staged to the first coarse
+    # grid, restored to pristine at the end.
+    for kf in keyframes:
+        assert tuple(kf["latent"].shape[-2:]) == (8, 8)
+    # Ref latents kept their existing behavior: never resized.
+    for ref in refs:
+        assert tuple(ref["latent"].shape[-2:]) == (8, 8)
+    # Pristine conditioning restored: same container object, same per-holder
+    # dicts, full-res tensors. No sampler code replaced or rebuilt
+    # guider.original_conds.
+    assert guider.original_conds is original_conds
+    cond = original_conds["positive"][0]
+    assert cond["minimax_keyframes"] is keyframes
+    assert cond["minimax_refs"] is refs
+    assert not hasattr(guider, _LW_ATTR)
+
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_i2v_failure_restores_pristine_conditioning(sampler):
+    guider, keyframes, refs, original_conds = _i2v_guider()
+
+    import speed_scripts.h3_runtime as rt
+
+    original_expand = rt.spectral_expand
+
+    def exploding_expand(value, target_hw, sigma, seed):
+        raise RuntimeError("i2v forced failure")
+
+    rt.spectral_expand = exploding_expand
+    try:
+        with pytest.raises(RuntimeError, match="i2v forced failure"):
+            _run(sampler, _explicit_ladder_cfg(3), guider)
+    finally:
+        rt.spectral_expand = original_expand
+
+    # The failure happened after stage 0 had already downscaled the
+    # keyframe latents; pristine conditioning is restored anyway.
+    for kf in keyframes:
+        assert tuple(kf["latent"].shape[-2:]) == (8, 8)
+    for ref in refs:
+        assert tuple(ref["latent"].shape[-2:]) == (8, 8)
+    assert guider.original_conds is original_conds
+    assert not hasattr(guider, _LW_ATTR)
+
+
+# ---------------------------------------------------------------------------
+# S6: Failure cleanup (source §9 remainder) — forced sampler-stage failure
+# through the real selector path, then a clean second generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_stage_failure_closes_handle_restores_and_drops_walker(sampler):
+    """Force a mid-run failure inside the second stage's guider.sample call:
+    the run-scoped handle is closed and the walker attribute is removed from
+    the guider (with no I2V conds attached, the walker's own restore is a
+    no-op — the pristine-restore path is pinned by the I2V tests above)."""
+    closed = []
+    events = []
+
+    class FailingCloseHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def close(self):
+            closed.append(True)
+
+    # Instrument the guider AFTER the factory patch: the failure must come
+    # from the stage call, not the handle.
+    class ExplodingStageGuider(RecordingEchoGuider):
+        def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+            events.append("sample")
+            if len(events) == 2:  # second stage
+                raise RuntimeError("stage exploded")
+            return super().sample(
+                noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+            )
+
+    guider = ExplodingStageGuider()
+    _original_factory = h3_runtime.create_speed_sampler_handle
+    h3_runtime.create_speed_sampler_handle = lambda name: FailingCloseHandle()
+    try:
+        with pytest.raises(RuntimeError, match="stage exploded"):
+            _run(sampler, _explicit_ladder_cfg(3), guider)
+    finally:
+        h3_runtime.create_speed_sampler_handle = _original_factory
+
+    assert closed == [True]
+    assert events == ["sample", "sample"]  # stage 2 never ran
+    assert not hasattr(guider, _LW_ATTR)
+
+
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+def test_second_generation_after_failure_starts_clean(sampler):
+    """After a failed run, the same guider can run a full generation: the
+    walker is recreated, the handle is rebuilt, and the output is identical
+    to a run that never saw the failure."""
+    class ExplodingStageGuider(RecordingEchoGuider):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.remaining_stage_failures = 0
+
+        def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+            if self.remaining_stage_failures > 0:
+                self.remaining_stage_failures -= 1
+                raise RuntimeError("first generation exploded")
+            return super().sample(
+                noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+            )
+
+    cfg = _explicit_ladder_cfg(3)
+
+    # Generation 1: fail in the first stage call.
+    guider_a = ExplodingStageGuider()
+    guider_a.remaining_stage_failures = 1
+    with pytest.raises(RuntimeError, match="first generation exploded"):
+        _run(sampler, cfg, guider_a)
+    assert not hasattr(guider_a, _LW_ATTR)
+
+    # Generation 2: same guider object, no special handling — must complete
+    # and match a control run that never failed.
+    out_second, _ = _run(sampler, cfg, guider_a)
+
+    guider_control = ExplodingStageGuider()
+    out_control, _ = _run(sampler, cfg, guider_control)
+
+    video_second, audio_second = out_second["samples"].unbind()
+    video_control, audio_control = out_control["samples"].unbind()
+    assert torch.equal(video_second, video_control)
+    assert torch.equal(audio_second, audio_control)
+    _assert_full_res_nested(out_second)
+    assert not hasattr(guider_a, _LW_ATTR)
+

--- a/speed_scripts/tests/test_sampler_support.py
+++ b/speed_scripts/tests/test_sampler_support.py
@@ -1,0 +1,507 @@
+"""Sampler-support contracts: public selector, run-scoped handle lifecycle,
+and Euler regression through the new handle layer.
+
+The selector tests pin the fail-closed public surface. The Euler regression
+tests replay the same fake-model run the pre-handle suite used and assert the
+sigma slices, transition boundaries, aligned-sigma patching, stage geometry,
+deterministic output, and callback count are unchanged. The lifecycle tests
+pin the hook position (once per configured transition, never per denoising
+step, never after the final stage) and the nested run-level cleanup order.
+
+Instrumented handles for the hook and cleanup tests enter through a patched
+``create_speed_sampler_handle`` in the runtime module namespace, so they
+exercise the same run-scoped handle path production uses; the override seam
+is covered separately.
+"""
+
+import pytest
+import torch
+
+from conftest import make_fake_noise, make_latent, make_recording_guider
+from speed_scripts import h3_runtime
+from speed_scripts.config import SpeedConfig
+from speed_scripts.flow import aligned_sigma
+from speed_scripts.h3_runtime import _LW_ATTR, run_speed_pipeline
+from speed_scripts.sampler_support import (
+    STATELESS_SPEED_SAMPLERS,
+    SUPPORTED_SPEED_SAMPLERS,
+    SamplerCapability,
+    SpeedTransition,
+    SpeedSamplerHandle,
+    create_speed_sampler_handle,
+)
+
+
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+
+def _cfg(**kwargs):
+    kwargs.setdefault("scales", (.33, .66, 1.0))
+    kwargs.setdefault("transition_steps", (3, 5))
+    return SpeedConfig(transition_mode="explicit", **kwargs)
+
+
+def _nested(video, audio):
+    return type(
+        "Nested",
+        (),
+        {"is_nested": True, "unbind": lambda self: [video, audio]},
+    )()
+
+
+class EchoGuider:
+    """Additive-echo guider (public = noise video + offset) with an event log.
+
+    Mirrors the pre-handle additive test guider: the public output is the
+    stage's public noise plus a fixed video offset. Records an ordered event
+    log, every sampler object it receives, and the video geometry of each
+    noise argument (the coarse/re-entry noise the stage consumes), so tests
+    can order the runtime's hook calls against the stage sampling calls.
+    """
+
+    class Model:
+        sigma_shift_video = 12.0
+        sigma_shift_audio = 3.0
+
+        def process_latent_out(self, x):
+            return x
+
+    def __init__(self, video_offset=0.0):
+        self.model_patcher = type("P", (), {"model": self.Model()})()
+        self.video_offset = video_offset
+        self.events = []
+        self.samplers = []
+        self.noise_shapes = []
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.events.append("sample")
+        self.samplers.append(sampler)
+        pub_video, pub_audio = list(noise.unbind())
+        self.noise_shapes.append(tuple(pub_video.shape))
+        out_video = pub_video + self.video_offset
+        out = _nested(out_video, pub_audio)
+        count = len(sigmas) - 1
+        if callback is not None:
+            for i in range(count):
+                callback(i, out, out, count)
+        return out
+
+
+class HookGuider(EchoGuider):
+    """EchoGuider that logs its sample calls into a test-owned event list."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.test_events = None
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        if self.test_events is not None:
+            self.test_events.append("sample")
+        return super().sample(
+            noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public selector (source §9 "Public selector")
+# ---------------------------------------------------------------------------
+
+def test_public_selector_is_exactly_the_four_stateless_names():
+    assert STATELESS_SPEED_SAMPLERS == ("euler", "heun", "dpm_2", "exp_heun_2_x0")
+    assert SUPPORTED_SPEED_SAMPLERS == STATELESS_SPEED_SAMPLERS
+
+
+@pytest.mark.parametrize("name", STATELESS_SPEED_SAMPLERS)
+def test_factory_accepts_each_supported_name(name):
+    handle = create_speed_sampler_handle(name)
+    assert isinstance(handle, SpeedSamplerHandle)
+    assert handle.capability is SamplerCapability.STATELESS_STEP_LOCAL
+    # Native Comfy sampler object for that name (conftest stub shape).
+    assert handle.sampler == ("sampler", name)
+
+
+@pytest.mark.parametrize("name", ["res_multistep", "dpmpp_2m", "Euler", "euler_ancestral", ""])
+def test_factory_rejects_unknown_names_fail_closed(name):
+    with pytest.raises(ValueError) as excinfo:
+        create_speed_sampler_handle(name)
+    message = str(excinfo.value)
+    assert name in message
+    for supported in SUPPORTED_SPEED_SAMPLERS:
+        assert supported in message
+
+
+def test_base_handle_is_an_inert_noop():
+    handle = SpeedSamplerHandle()
+    assert handle.on_transition(
+        SpeedTransition(
+            stage_idx=0, ratio=2.0, old_sigma=.7, new_sigma=.5,
+            source_thw=(2, 3, 3), target_thw=(2, 5, 5),
+        )
+    ) is None
+    assert handle.close() is None
+
+
+# ---------------------------------------------------------------------------
+# Euler regression (source §9 "Euler regression")
+# ---------------------------------------------------------------------------
+
+def test_default_and_explicit_paths_select_euler_exactly_once_per_run(monkeypatch):
+    selected = []
+
+    def recording_factory(name):
+        selected.append(name)
+        return create_speed_sampler_handle(name)
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", recording_factory)
+    for kwargs in ({}, {"sampler_name": "euler"}):
+        selected.clear()
+        guider = make_recording_guider()
+        run_speed_pipeline(
+            make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+            disable_pbar=True, **kwargs,
+        )
+        assert selected == ["euler"]
+
+
+def test_euler_sigma_slices_and_boundaries_are_unchanged():
+    """Stage slices use GLOBAL boundaries and the boundary coordinate is
+    patched in place with the kappa-aligned sigma."""
+    calls = []
+    guider = make_recording_guider(sigma_calls=calls)
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+    )
+
+    working = [float(s) for s in SIGMAS]
+    boundaries = (3, 5)
+    scales = (.33, .66, 1.0)
+    expected = []
+    for stage, end in enumerate(boundaries):
+        start = boundaries[stage - 1] if stage else 0
+        expected.append(working[start:end + 1])
+        ratio = scales[stage + 1] / scales[stage]
+        _, working[end] = aligned_sigma(working[end], ratio)
+    expected.append(working[boundaries[-1]:])
+
+    assert len(calls) == 3
+    for actual, wanted in zip(calls, expected):
+        assert actual == pytest.approx(wanted)
+    assert sum(len(call) - 1 for call in calls) == len(SIGMAS) - 1
+
+
+def test_euler_routes_the_handle_sampler_into_every_guider_call(monkeypatch):
+    marker = object()
+
+    class MarkerHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = marker
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: MarkerHandle())
+    guider = EchoGuider()
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+    )
+    # The coarse stages and the final stage all sampled through the handle's
+    # sampler object — the old hardcoded euler construction is gone.
+    assert len(guider.samplers) == 3
+    assert all(sampler is marker for sampler in guider.samplers)
+
+
+def test_euler_stage_geometry_is_unchanged():
+    """Stage cond geometry follows the configured scale ladder and each
+    stage consumes noise at its own grid: coarse 3x3, expanded 5x5, final 8x8."""
+    stage_shapes = []
+    guider = make_recording_guider(stage_shapes=stage_shapes)
+    noise_guider = EchoGuider()
+    latent = make_latent()
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, latent, _cfg(),
+        disable_pbar=True,
+    )
+    run_speed_pipeline(
+        make_fake_noise(), noise_guider, SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+    )
+    # round(8 * .33) = 3, round(8 * .66) = 5, final stage at full 8; the
+    # noise video keeps its leading batch/channel dims (1, 1, t, h, w).
+    assert stage_shapes == [(3, 3), (5, 5), (8, 8)]
+    assert noise_guider.noise_shapes == [(1, 1, 2, 3, 3), (1, 1, 2, 5, 5), (1, 1, 2, 8, 8)]
+
+
+def test_euler_run_is_deterministic():
+    """Same seed and same fake model: two identical runs produce the same
+    final video latent."""
+    latent = make_latent()
+    out, _ = run_speed_pipeline(
+        make_fake_noise(), EchoGuider(video_offset=.5), SIGMAS, latent, _cfg(),
+        disable_pbar=True,
+    )
+    in_video, in_audio = latent["samples"].unbind()
+    out_video, out_audio = out["samples"].unbind()
+    assert out_video.shape == in_video.shape
+    assert out_audio.shape == in_audio.shape
+    out_again, _ = run_speed_pipeline(
+        make_fake_noise(), EchoGuider(video_offset=.5), SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+    )
+    again_video, _ = out_again["samples"].unbind()
+    assert torch.equal(out_video, again_video)
+
+
+def test_euler_callback_count_equals_global_denoising_intervals():
+    seen = []
+    guider = EchoGuider(video_offset=.5)
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+        preview_callback=lambda step, x0, x, total: seen.append((step, total)),
+    )
+    # A (3, 5) ladder over a 10-interval schedule forwards exactly 10
+    # callbacks on one continuous global timeline — the pre-handle count.
+    assert seen == [(i, 10) for i in range(10)]
+
+
+# ---------------------------------------------------------------------------
+# Hook position (source §7) — once per configured transition
+# ---------------------------------------------------------------------------
+
+def test_transition_hook_fires_once_per_transition_at_the_documented_position(monkeypatch):
+    events = []
+    transitions_seen = []
+
+    class HookHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def on_transition(self, transition):
+            events.append("hook")
+            transitions_seen.append(transition)
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: HookHandle())
+    guider = HookGuider(video_offset=.5)
+    guider.test_events = events
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+    )
+
+    scales = (.33, .66, 1.0)
+    # Exactly the two configured transitions: not per denoising step (10
+    # intervals) and not after the final stage (no third hook). Each hook
+    # sits between its stage's guider.sample and the next stage's sample.
+    assert events == ["sample", "hook", "sample", "hook", "sample"]
+    assert [t.stage_idx for t in transitions_seen] == [0, 1]
+    assert [t.ratio for t in transitions_seen] == [
+        pytest.approx(scales[1] / scales[0]), pytest.approx(scales[2] / scales[1]),
+    ]
+    # Each hook reads the boundary coordinate it is aligning: stage 0 reads
+    # schedule index 3 (0.7), stage 1 reads index 5 (0.5); new_sigma is the
+    # aligned coordinate patched into the working schedule.
+    _, new0 = aligned_sigma(.7, scales[1] / scales[0])
+    _, new1 = aligned_sigma(.5, scales[2] / scales[1])
+    assert transitions_seen[0].old_sigma == pytest.approx(.7)
+    assert transitions_seen[0].new_sigma == pytest.approx(new0)
+    assert transitions_seen[1].old_sigma == pytest.approx(.5)
+    assert transitions_seen[1].new_sigma == pytest.approx(new1)
+    # Spectral transition ran before the hook: source geometry is this
+    # stage's grid, target geometry is the next stage's grid.
+    assert transitions_seen[0].source_thw == (2, 3, 3)
+    assert transitions_seen[0].target_thw == (2, 5, 5)
+    assert transitions_seen[1].source_thw == (2, 5, 5)
+    assert transitions_seen[1].target_thw == (2, 8, 8)
+
+
+def test_hook_failure_aborts_the_run_before_the_next_stage_samples(monkeypatch):
+    """The hook belongs to the gap between two stages: when it raises, the
+    next stage never samples — and run-level cleanup still runs."""
+
+    class ExplodingHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def on_transition(self, transition):
+            if transition.stage_idx == 0:
+                raise RuntimeError("hook exploded")
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: ExplodingHandle())
+    guider = EchoGuider()
+    with pytest.raises(RuntimeError, match="hook exploded"):
+        run_speed_pipeline(
+            make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+            disable_pbar=True,
+        )
+    assert guider.events.count("sample") == 1
+    assert not hasattr(guider, _LW_ATTR)
+
+
+def test_coincident_boundaries_still_call_the_hook_once_each(monkeypatch):
+    transitions_seen = []
+    events = []
+
+    class HookHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def on_transition(self, transition):
+            events.append("hook")
+            transitions_seen.append(transition.stage_idx)
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: HookHandle())
+    # delta_custom quantizes both transitions onto the same schedule index
+    # (the existing suite pins boundaries == (1, 1) for these parameters) —
+    # the legal coincident-boundary case.
+    cfg = SpeedConfig(
+        scales=(.25, .5, 1.0),
+        transition_steps=(3, 5),
+        transition_mode="delta_custom",
+        delta=.01,
+        noise_amplitude=219.48,
+        noise_decay_exponent=2.42,
+        full_latent_h=8,
+        full_latent_w=8,
+    )
+    guider = HookGuider()
+    guider.test_events = events
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), cfg,
+        disable_pbar=True,
+    )
+    # Both transitions fire at the coincident boundary, each between its own
+    # stage's sample calls; the zero-step intermediate stage still runs.
+    assert transitions_seen == [0, 1]
+    assert events == ["sample", "hook", "sample", "hook", "sample"]
+
+
+# ---------------------------------------------------------------------------
+# Run-scoped lifecycle (source §6 cleanup structure)
+# ---------------------------------------------------------------------------
+
+def test_cleanup_runs_close_then_restore_then_drop_on_success(monkeypatch):
+    order = []
+
+    class CleanupHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def close(self):
+            order.append("close")
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: CleanupHandle())
+    monkeypatch.setattr(
+        h3_runtime.LatentWalker, "apply_final", lambda self: order.append("apply_final")
+    )
+    guider = make_recording_guider()
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+        disable_pbar=True,
+    )
+    # apply_final also runs once before the final stage (pre-final restore);
+    # the run-level cleanup then closes the sampler handle, restores again,
+    # and drops the walker from the guider.
+    assert order == ["apply_final", "close", "apply_final"]
+    assert not hasattr(guider, _LW_ATTR)
+
+
+def test_cleanup_still_restores_and_drops_when_sampler_close_fails(monkeypatch):
+    order = []
+
+    class FailingHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def close(self):
+            order.append("close")
+            raise RuntimeError("close exploded")
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: FailingHandle())
+    monkeypatch.setattr(
+        h3_runtime.LatentWalker, "apply_final", lambda self: order.append("apply_final")
+    )
+    guider = make_recording_guider()
+    with pytest.raises(RuntimeError, match="close exploded"):
+        run_speed_pipeline(
+            make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+            disable_pbar=True,
+        )
+    # The failing close did not stop the walker restore (which also runs
+    # once earlier, before the final stage), and the walker was still
+    # dropped from the guider.
+    assert order == ["apply_final", "close", "apply_final"]
+    assert not hasattr(guider, _LW_ATTR)
+
+
+def test_cleanup_still_drops_the_walker_when_the_restore_fails(monkeypatch):
+    """If walker.apply_final() itself raises, _drop_walker() must still run —
+    the innermost finally of the required cleanup structure."""
+    order = []
+
+    class CleanupHandle(SpeedSamplerHandle):
+        def __init__(self):
+            self.sampler = object()
+            self.capability = SamplerCapability.STATELESS_STEP_LOCAL
+
+        def close(self):
+            order.append("close")
+
+    def exploding_final(self):
+        order.append("apply_final")
+        raise RuntimeError("restore exploded")
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", lambda name: CleanupHandle())
+    monkeypatch.setattr(h3_runtime.LatentWalker, "apply_final", exploding_final)
+    guider = make_recording_guider()
+    # The restore also runs once before the final stage; the FIRST failing
+    # restore aborts the run there. The close still ran after it, and the
+    # walker was still dropped from the guider.
+    with pytest.raises(RuntimeError, match="restore exploded"):
+        run_speed_pipeline(
+            make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+            disable_pbar=True,
+        )
+    assert order == ["apply_final", "close", "apply_final"]
+    assert not hasattr(guider, _LW_ATTR)
+
+
+# ---------------------------------------------------------------------------
+# Override seam and fail-closed runtime validation
+# ---------------------------------------------------------------------------
+
+def test_override_seam_wraps_the_injected_sampler_as_a_noop_handle():
+    injected = object()
+    guider = EchoGuider()
+    run_speed_pipeline(
+        make_fake_noise(), guider, SIGMAS, make_latent(), _cfg(),
+        sampler_override=injected, disable_pbar=True,
+    )
+    assert guider.samplers[0] is injected
+    assert guider.samplers[1] is injected
+    assert guider.samplers[2] is injected
+
+
+def test_override_seam_rejects_combination_with_explicit_sampler_name():
+    with pytest.raises(ValueError):
+        run_speed_pipeline(
+            make_fake_noise(), make_recording_guider(), SIGMAS, make_latent(),
+            _cfg(), sampler_name="heun", sampler_override=object(),
+            disable_pbar=True,
+        )
+
+
+def test_run_rejects_unsupported_sampler_name_fail_closed():
+    with pytest.raises(ValueError) as excinfo:
+        run_speed_pipeline(
+            make_fake_noise(), make_recording_guider(), SIGMAS, make_latent(),
+            _cfg(), sampler_name="dpmpp_2m", disable_pbar=True,
+        )
+    message = str(excinfo.value)
+    assert "dpmpp_2m" in message
+    for supported in SUPPORTED_SPEED_SAMPLERS:
+        assert supported in message

--- a/speed_scripts/tests/test_top5_samplers.py
+++ b/speed_scripts/tests/test_top5_samplers.py
@@ -1,0 +1,255 @@
+"""Cross-sampler execution tests for the PR A stateless samplers
+(plan §9 Heun / DPM2 / Exp Heun 2 X0 blocks).
+
+All stateless samplers share one runtime path — the run-scoped handle feeds
+the same stage loop — so the checks run parameterized over ``heun``,
+``dpm_2`` and ``exp_heun_2_x0``, with ``euler`` (the S2 regression anchor,
+already pinned in ``test_sampler_support.py``) appearing only as the
+differential baseline for stage scheduling and inside the
+coincident-boundary completion sweep.
+
+What these tests pin is what SPEED owes every sampler: each stage hands the
+solver its complete interval set in one ``guider.sample`` call (so a
+multi-evaluation solver's extra model evaluations stay inside one interval
+and a SPEED transition lands only between completed intervals), public
+progress stays at one callback per global denoising interval, coincident
+boundaries and zero-step stages complete, and the deterministic Exp Heun 2
+X0 path reproduces exactly. Solver math itself stays inside ComfyUI's
+native sampler objects and is never re-implemented or inspected here.
+"""
+
+import pytest
+import torch
+
+from conftest import make_latent
+from speed_scripts.automatic_config import STAGES_TO_SCALES
+from speed_scripts.config import SpeedConfig
+from speed_scripts.h3_runtime import run_speed_pipeline
+from speed_scripts.sampler_support import (
+    STATELESS_SPEED_SAMPLERS,
+    create_speed_sampler_handle,
+)
+
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+#: The three samplers this slice adds on top of the Euler regression anchor.
+NEW_SAMPLERS = ("heun", "dpm_2", "exp_heun_2_x0")
+
+#: Explicit stage ladders for the 2/3/4-stage completion tests: production
+#: Automatic scale ladders with unique, strictly increasing global boundaries
+#: that tile the 10-interval schedule (5 + 5, 3 + 2 + 5, 2 + 2 + 3 + 3).
+LADDER_BOUNDARIES = {2: (5,), 3: (3, 5), 4: (2, 4, 7)}
+
+
+def _nested(video, audio):
+    return type(
+        "Nested",
+        (),
+        {"is_nested": True, "unbind": lambda self: [video, audio]},
+    )()
+
+
+def _explicit_ladder_cfg(stages):
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=LADDER_BOUNDARIES[stages],
+        transition_mode="explicit",
+    )
+
+
+def _automatic_calibrated_cfg(stages):
+    """The Automatic node's delta_custom config for ``stages`` stages.
+
+    With the baked calibration constants on the 10-interval schedule every
+    transition quantizes onto schedule index 1, so the middle stages get a
+    single-sigma schedule (zero denoising steps) — the legal
+    coincident-boundary case the runtime must support.
+    """
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=tuple(range(1, len(STAGES_TO_SCALES[stages]))),
+        transition_mode="delta_custom",
+        delta=.005,
+        noise_amplitude=12.105,
+        noise_decay_exponent=.773,
+        full_latent_h=8,
+        full_latent_w=8,
+    )
+
+
+class RecordingEchoGuider:
+    """Echo guider that records what every stage call received.
+
+    The public output is the stage's noise video plus a fixed offset, so a
+    finished run carries non-trivial signal. Records the sampler object, the
+    sigma schedule, and the noise geometry of each ``sample`` call.
+    """
+
+    class Model:
+        sigma_shift_video = 12.0
+        sigma_shift_audio = 3.0
+
+        def process_latent_out(self, x):
+            return x
+
+    def __init__(self, video_offset=0.0):
+        self.model_patcher = type("P", (), {"model": self.Model()})()
+        self.video_offset = video_offset
+        self.samplers = []
+        self.sigma_calls = []
+        self.noise_shapes = []
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        self.sigma_calls.append([float(s) for s in sigmas])
+        pub_video, pub_audio = list(noise.unbind())
+        self.noise_shapes.append(tuple(pub_video.shape))
+        out = _nested(pub_video + self.video_offset, pub_audio)
+        count = len(sigmas) - 1
+        if callback is not None:
+            for i in range(count):
+                callback(i, out, out, count)
+        return out
+
+
+class SeededRandomNoise:
+    """Noise source returning seeded random noise, so run outputs are
+    non-trivial and determinism is not vacuously true over zero inputs."""
+
+    def __init__(self, seed=42):
+        self.seed = seed
+
+    def generate_noise(self, latent):
+        video, audio = list(latent["samples"].unbind())
+        generator = torch.Generator().manual_seed(self.seed)
+        return _nested(
+            torch.randn(video.shape, generator=generator),
+            torch.randn(audio.shape, generator=generator),
+        )
+
+
+def _run(sampler, cfg, guider, **kwargs):
+    return run_speed_pipeline(
+        SeededRandomNoise(), guider, SIGMAS, make_latent(), cfg,
+        sampler_name=sampler, disable_pbar=True, **kwargs,
+    )
+
+
+def _assert_full_res_nested(latent):
+    """Both H3 streams survived: 5-dim video + 4-dim audio at full 8x8."""
+    video, audio = latent["samples"].unbind()
+    assert video.ndim == 5 and audio.ndim == 4
+    assert tuple(video.shape[-2:]) == (8, 8)
+
+
+# ---------------------------------------------------------------------------
+# Parameterized 2/3/4-stage completion (plan §9 Heun block; DPM2 and
+# Exp Heun 2 X0 inherit via "same execution checks as Heun")
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sampler", NEW_SAMPLERS)
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_stage_ladder_completes_at_full_resolution(sampler, stages):
+    guider = RecordingEchoGuider(video_offset=.5)
+    out, denoised = _run(sampler, _explicit_ladder_cfg(stages), guider)
+
+    assert len(guider.sigma_calls) == stages
+    assert len(guider.noise_shapes) == stages
+    # Nested H3 video+audio output survives on both node outputs, and the
+    # final geometry is full resolution.
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+
+
+# ---------------------------------------------------------------------------
+# Stage scheduling is sampler-independent (plan §2: scheduler logic never
+# branches on the sampler name). Whole-interval slices in one call per stage
+# also mean a Heun second evaluation / DPM2 midpoint stays inside one
+# sampler interval, and a SPEED transition can only land between completed
+# intervals.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sampler", NEW_SAMPLERS)
+def test_stage_slices_match_the_euler_baseline(sampler):
+    cfg = _explicit_ladder_cfg(3)
+    baseline = RecordingEchoGuider()
+    _run("euler", cfg, baseline)
+    guider = RecordingEchoGuider()
+    _run(sampler, cfg, guider)
+    assert guider.sigma_calls == baseline.sigma_calls
+
+
+@pytest.mark.parametrize("sampler", NEW_SAMPLERS)
+def test_every_stage_samples_through_the_selected_native_sampler(sampler):
+    guider = RecordingEchoGuider()
+    _run(sampler, _explicit_ladder_cfg(3), guider)
+    # The factory-built native Comfy sampler object for the selected name
+    # reached every stage call — never a silent Euler substitute.
+    assert guider.samplers == [("sampler", sampler)] * 3
+
+
+# ---------------------------------------------------------------------------
+# Coincident boundaries + zero-step stages complete (plan §9 Heun block;
+# euler included to anchor the sweep)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sampler", STATELESS_SPEED_SAMPLERS)
+@pytest.mark.parametrize("stages", (3, 4))
+def test_coincident_boundary_ladders_complete_with_zero_step_stages(sampler, stages):
+    cfg = _automatic_calibrated_cfg(stages)
+    guider = RecordingEchoGuider()
+    out, _ = _run(sampler, cfg, guider)
+
+    assert len(guider.sigma_calls) == stages
+    # Every middle stage quantized onto the same boundary coordinate: its
+    # schedule is a single sigma (zero denoising steps) yet the stage still
+    # ran, and the run finished at full resolution.
+    for call in guider.sigma_calls[1:-1]:
+        assert len(call) == 1
+    _assert_full_res_nested(out)
+
+
+# ---------------------------------------------------------------------------
+# Public progress (plan §9: callback count equals global denoising
+# intervals, not model evaluations — Heun's second evaluation and DPM2's
+# midpoint evaluation must not surface as extra public progress steps)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sampler", NEW_SAMPLERS)
+def test_callback_count_equals_global_denoising_intervals(sampler):
+    seen = []
+    guider = RecordingEchoGuider(video_offset=.5)
+    _run(
+        sampler, _explicit_ladder_cfg(3), guider,
+        preview_callback=lambda step, x0, x, total: seen.append((step, total)),
+    )
+    # A (3, 5) ladder over a 10-interval schedule forwards exactly 10
+    # callbacks on one continuous global timeline.
+    assert seen == [(i, 10) for i in range(10)]
+
+
+# ---------------------------------------------------------------------------
+# Exp Heun 2 X0 (plan §9: deterministic repeat-run reproducibility; no
+# stochastic path)
+# ---------------------------------------------------------------------------
+
+def test_exp_heun_2_x0_repeat_run_is_reproducible():
+    cfg = _explicit_ladder_cfg(3)
+    out, _ = _run("exp_heun_2_x0", cfg, RecordingEchoGuider(video_offset=.5))
+    out_again, _ = _run(
+        "exp_heun_2_x0", cfg, RecordingEchoGuider(video_offset=.5)
+    )
+    video, _ = out["samples"].unbind()
+    again_video, _ = out_again["samples"].unbind()
+    assert torch.equal(video, again_video)
+    # The comparison is meaningful: the run carried non-trivial signal.
+    assert video.abs().sum() > 0
+
+
+def test_stochastic_exp_heun_variant_is_rejected_fail_closed():
+    with pytest.raises(ValueError) as excinfo:
+        create_speed_sampler_handle("exp_heun_2_x0_sde")
+    message = str(excinfo.value)
+    assert "exp_heun_2_x0_sde" in message
+    for supported in STATELESS_SPEED_SAMPLERS:
+        assert supported in message

--- a/speed_scripts/tests/test_top5_samplers.py
+++ b/speed_scripts/tests/test_top5_samplers.py
@@ -21,7 +21,12 @@ native sampler objects and is never re-implemented or inspected here.
 import pytest
 import torch
 
-from conftest import make_latent
+from conftest import (
+    LADDER_BOUNDARIES,
+    RecordingEchoGuider,
+    SeededRandomNoise,
+    make_latent,
+)
 from speed_scripts.automatic_config import STAGES_TO_SCALES
 from speed_scripts.config import SpeedConfig
 from speed_scripts.h3_runtime import run_speed_pipeline
@@ -34,11 +39,6 @@ SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
 
 #: The three samplers this slice adds on top of the Euler regression anchor.
 NEW_SAMPLERS = ("heun", "dpm_2", "exp_heun_2_x0")
-
-#: Explicit stage ladders for the 2/3/4-stage completion tests: production
-#: Automatic scale ladders with unique, strictly increasing global boundaries
-#: that tile the 10-interval schedule (5 + 5, 3 + 2 + 5, 2 + 2 + 3 + 3).
-LADDER_BOUNDARIES = {2: (5,), 3: (3, 5), 4: (2, 4, 7)}
 
 
 def _nested(video, audio):
@@ -75,57 +75,6 @@ def _automatic_calibrated_cfg(stages):
         full_latent_h=8,
         full_latent_w=8,
     )
-
-
-class RecordingEchoGuider:
-    """Echo guider that records what every stage call received.
-
-    The public output is the stage's noise video plus a fixed offset, so a
-    finished run carries non-trivial signal. Records the sampler object, the
-    sigma schedule, and the noise geometry of each ``sample`` call.
-    """
-
-    class Model:
-        sigma_shift_video = 12.0
-        sigma_shift_audio = 3.0
-
-        def process_latent_out(self, x):
-            return x
-
-    def __init__(self, video_offset=0.0):
-        self.model_patcher = type("P", (), {"model": self.Model()})()
-        self.video_offset = video_offset
-        self.samplers = []
-        self.sigma_calls = []
-        self.noise_shapes = []
-
-    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
-        self.samplers.append(sampler)
-        self.sigma_calls.append([float(s) for s in sigmas])
-        pub_video, pub_audio = list(noise.unbind())
-        self.noise_shapes.append(tuple(pub_video.shape))
-        out = _nested(pub_video + self.video_offset, pub_audio)
-        count = len(sigmas) - 1
-        if callback is not None:
-            for i in range(count):
-                callback(i, out, out, count)
-        return out
-
-
-class SeededRandomNoise:
-    """Noise source returning seeded random noise, so run outputs are
-    non-trivial and determinism is not vacuously true over zero inputs."""
-
-    def __init__(self, seed=42):
-        self.seed = seed
-
-    def generate_noise(self, latent):
-        video, audio = list(latent["samples"].unbind())
-        generator = torch.Generator().manual_seed(self.seed)
-        return _nested(
-            torch.randn(video.shape, generator=generator),
-            torch.randn(audio.shape, generator=generator),
-        )
 
 
 def _run(sampler, cfg, guider, **kwargs):


### PR DESCRIPTION
# SPEED top-5 samplers (PR A): euler/heun/dpm_2/exp_heun_2_x0 via a run-scoped sampler handle

## What this changes

SPEED previously ran on Euler only. This branch adds three more ComfyUI
samplers to both SPEED nodes: **Heun**, **DPM2** (`dpm_2`), and **Exp Heun 2
X0** (`exp_heun_2_x0`). The Automatic node and the Manual Step-Through node
each get an optional `sampler_name` dropdown. Leaving it unset (or loading an
old workflow that does not have the field) gives exactly the old Euler
behavior.

The support list is intentionally restricted to these four names. The fifth
candidate, `res_multistep` (RES), keeps step history across stage boundaries
and is deliberately not public yet. The README documents the four samplers
only, on purpose.

## Why this change exists

SPEED (the multi-stage trick this pack implements: start the denoise at low
resolution, move to full resolution partway through, and save wall-clock
time) was hard-wired to Euler because the sigma-harvest calibration and the
boundary alignment math were derived on Euler. That made the pack unusable
for people who want other samplers, even ones ComfyUI already ships. This
branch wires the four stateless native ComfyUI samplers through the existing
SPEED pipeline without adding any new solver math, so the calibration
guarantees stay intact.

## How it works

1. A new module, `speed_scripts/sampler_support.py`, holds the one source of
   truth: `SUPPORTED_SPEED_SAMPLERS == ("euler", "heun", "dpm_2",
   "exp_heun_2_x0")`.
2. Both nodes append the `sampler_name` dropdown as the last widget. An
   unknown name raises a `ValueError` that lists the invalid and the
   supported names. There is no silent fallback to Euler.
3. `run_speed_pipeline` accepts `sampler_name` (or a direct
   `sampler_override`). At each stage transition it asks
   `comfy.samplers.sampler_object(name)` for the real native sampler object
   and hands it to the guider through a small handle.
4. The handle is run-scoped: it is created when the run starts and closed
   when the run ends, even on failure. All four supported samplers are
   stateless, so the handle is a no-op today, but it gives the future RES
   sampler (which keeps history) a defined place to save and restore state.
   A sampler that carries history across calls, such as
   `exp_heun_2_x0_sde`, is rejected.

## Commits

- 359ea0a feat: sampler-support foundation + Euler through run-scoped handle
- 0ca3f46 feat: optional sampler selector on Automatic + Manual nodes
- 1d64391 feat: native Heun, DPM2, Exp Heun 2 X0 sampler support
- 3c49353 test+docs: PR A suite gates — noise policies, Turbo/I2V/progress coverage; four-sampler docs
- d8e941e style: drop two stray double blank lines in S6 test block

Each commit has its own comment on the pull request conversation, in this
order.

## What was verified locally

All commands ran in this container against tip `d8e941e`:

- Full suite: `.venv/bin/python -m pytest speed_scripts/tests/ -q` —
  **153 passed, 0 failed, 0 skipped** in 0.60s.
- Test-count history as slices landed: 89 (selector + foundation) → 117
  (+28 tests for Heun/DPM2/Exp-Heun) → 153 (+36 suite-level tests: noise
  policies, progress/preview, Turbo stress, image-to-video, failure
  cleanup).
- Euler regression: saved workflows without the new field still run Euler,
  and tests compare those latents against explicit Euler runs.
- Selector contents: the public list equals the four stateless names above.
  `res_multistep` is rejected by a test, and
  `exp_heun_2_x0_sde` (which carries state) is rejected by a test.
- The complete diff was reviewed by an independent reviewer who did not
  write the code. The review passed with no unresolved critical findings.

## What still needs a human on real hardware

This container has no GPU and no ComfyUI installation. The following are
**not done** and are **not claimed as passed**:

1. Real MiniMax-H3 smoke runs for all four samplers, including checking that
   Heun's second model evaluation per step behaves sanely (implementation
   plan, section 10).
2. Manually loading at least one old Euler workflow in a real ComfyUI to
   confirm it still loads and runs (plan, section 3).
3. Wall-clock benchmarks on a GPU machine (plan, sections 27–28).
4. The merge decision, after those checks.

## Compatibility and rollout

- Old saved workflows keep working: the new field is last in the widget
  order (pinned by exact-key-tuple tests) and a missing field means Euler.
- Calibration values, widget defaults, and the Sigma Harvest node are
  unchanged.
- Continuous integration: the repository has one workflow,
  `branch-guard.yml`, which only runs on pull requests into `main`. No CI
  runs on dev pull requests, so the local suite above is the check.

## Risks and review focus

- The dropdown order on both nodes is append-only; reordering widgets in
  ComfyUI shifts saved workflow values, so the tests pin the exact widget
  key order.
- `sampler_name` combined with a conflicting manual `sampler_override`
  raises a `ValueError` instead of picking one quietly.

## Rollback

Revert the merge commit on dev. No migrations, no stored data, no default
changes.
