### PR TITLE
SPEED top-5 samplers (PR B): RES Multistep — stateful adapter, stacked on PR A

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,15 @@ restricted: **Euler**, **Heun**, **DPM2** (`dpm_2`), and **Exp Heun 2 X0**
   pipeline. They can use extra model evaluations per step (for example
   Heun's second evaluation), which can reduce the wall-clock gains SPEED
   buys you.
-- **RES** (`res_multistep`) is not public yet. It keeps step history across
-  stage boundaries and ships only after its state-preservation tests and
-  real validation pass.
+- **RES** (`res_multistep`) is implemented on this branch but **not publicly
+  selectable** — the dropdown still lists exactly the four samplers above.
+  The adapter keeps its step history across SPEED stage boundaries: the
+  previous denoised estimate and its sigma metadata travel with the run, the
+  clean history is projected to each next stage's resolution, and the sigma
+  metadata is rebased at the boundary. It is deterministic and non-ancestral
+  only (no SDE, no CFG++). It stays experimental pending real H3 GPU
+  validation; until that passes, the state-preservation work lives in
+  `speed_scripts/tests/` and the sampler stays out of the public list.
 
 Workflow wires are the same for all three nodes: `noise` → `guider` → `sigmas` → `latent_image` → `output_latent` → `VAE Decode`.
 

--- a/conftest.py
+++ b/conftest.py
@@ -35,7 +35,53 @@ def install_comfy_stubs():
             return list(self._tensors)
 
     nested_tensor.NestedTensor = NestedTensor
+    class KSAMPLER:
+        """Host ``comfy.samplers.KSAMPLER`` contract, minimally modeled.
+
+        Mirrors the real ``KSAMPLER.sample(model_wrap, sigmas, extra_args,
+        callback, noise, latent_image, denoise_mask, disable_pbar)`` shape:
+        injects ``denoise_mask`` into ``extra_args``, wraps the guider in the
+        inpaint-style model callable (whose inner call receives only
+        ``(x, sigma, model_options, seed)`` — the mask blending lives in the
+        wrapper), runs the sampler function, and adapts the per-step dict
+        callback to the native 4-arg callback. Only what SPEED exercises is
+        modeled — no noise_scaling step, because test guiders receive
+        already-processed stage tensors.
+        """
+
+        def __init__(self, sampler_function, extra_options=None):
+            self.sampler_function = sampler_function
+            self.extra_options = extra_options or {}
+
+        def sample(self, model_wrap, sigmas, extra_args, callback, noise,
+                   latent_image=None, denoise_mask=None, disable_pbar=False):
+            extra_args = dict(extra_args)
+            extra_args["denoise_mask"] = denoise_mask
+            model = _InpaintModel(model_wrap)
+            total_steps = len(sigmas) - 1
+
+            def k_callback(entry):
+                if callback is not None:
+                    callback(entry["i"], entry["denoised"], entry["x"], total_steps)
+
+            return self.sampler_function(
+                model, noise, sigmas, extra_args=extra_args,
+                callback=k_callback, disable=disable_pbar,
+                **self.extra_options,
+            )
+
+    class _InpaintModel:
+        """Host ``KSamplerX0Inpaint`` shape: mask in the wrapper, inner call
+        receives ``(x, sigma, model_options, seed)`` only."""
+
+        def __init__(self, inner):
+            self.inner = inner
+
+        def __call__(self, x, sigma, denoise_mask=None, model_options={}, seed=None):
+            return self.inner(x, sigma, model_options=model_options, seed=seed)
+
     samplers.sampler_object = lambda name: ("sampler", name)
+    samplers.KSAMPLER = KSAMPLER
     utils.PROGRESS_BAR_ENABLED = True
 
     class ProgressBar:

--- a/speed_scripts/h3_runtime.py
+++ b/speed_scripts/h3_runtime.py
@@ -606,7 +606,10 @@ def run_speed_pipeline(
             # the next stage re-enters guider.sample(). Stateless samplers
             # no-op here; stateful samplers (PR B) preserve their step
             # history across the boundary. Never called per denoising step
-            # and never after the final stage.
+            # and never after the final stage. The per-stream shapes let a
+            # stateful handle slice its flat packed history (the real host
+            # packs nested latents before the sampler sees them) back into
+            # video and audio.
             sampler_handle.on_transition(
                 SpeedTransition(
                     stage_idx=stage_idx,
@@ -615,6 +618,10 @@ def run_speed_pipeline(
                     new_sigma=new_q,
                     source_thw=tuple(internal_video.shape[-3:]),
                     target_thw=(next_t, next_h, next_w),
+                    source_stream_shapes=(
+                        tuple(public_video.shape),
+                        tuple(public_audio.shape),
+                    ),
                 )
             )
 

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -26,6 +26,22 @@ from .flow import aligned_sigma
 from .spectral import spectral_expand_clean_3d
 
 
+def _host_ksampler_class():
+    """The host's real ``KSAMPLER`` class, resolved lazily.
+
+    Importing it at module load would break ComfyUI-free environments (the
+    surrounding package and its tests must import without a full ComfyUI
+    install, which only provides ``comfy.samplers`` at runtime). ``None``
+    means no real host is installed; then only the sampler-function contract
+    is available and the object must not pretend otherwise.
+    """
+    try:
+        from comfy.samplers import KSAMPLER
+    except Exception:
+        return None
+    return KSAMPLER
+
+
 @dataclass
 class ResMultistepState:
     """Step history one RES run carries across SPEED stage boundaries.
@@ -48,26 +64,68 @@ class ResMultistepState:
         self.prev_sigma_in = None
 
 
-def project_clean_history(history, target_thw: tuple[int, int, int]):
+def project_clean_history(history, target_thw: tuple[int, int, int], source_stream_shapes=None):
     """Project one clean RES history to the target video geometry.
 
-    ``history`` is the nested H3 denoised estimate (video ``[B,C,T,H,W]`` +
-    audio ``[B,C,2,T_audio]``) stored as solver history in
+    ``history`` is the clean denoised estimate stored as solver history in
     ``ResMultistepState.old_denoised``. Only the video geometry is projected,
     with :func:`spectral_expand_clean_3d` — the estimate is clean solver
     history, so it never receives fresh high-frequency noise and is never
     scaled by sigma. The clean audio estimate is preserved unchanged and is
     not sigma-reindexed: the boundary sigma belongs to the noisy re-entry
     state, not to this history.
+
+    Two shapes arrive here, depending on where the history was captured:
+
+    * the nested H3 video/audio pair (video ``[B,C,T,H,W]`` + audio
+      ``[B,C,2,T_audio]``) a guider hands back when it executes the sampler
+      directly; or
+    * the flat tensor the real host produces at the sampler boundary. The
+      host ``CFGGuider.sample`` packs nested video+audio with
+      ``comfy.utils.pack_latents`` (each stream reshaped ``[B, 1, -1]``, then
+      concatenated on the last axis) before any sampler code runs, so the
+      model's denoised output — and therefore this history — is a plain
+      ``[B, 1, N]`` tensor. ``source_stream_shapes`` carries the per-stream
+      shapes from that pack; the video slice is the first
+      ``prod(video_shape[1:])`` elements and the audio slice is the rest.
     """
-    if not getattr(history, "is_nested", False):
-        raise ValueError("RES clean history must be a nested H3 video/audio pair")
-    streams = list(history.unbind())
-    if len(streams) != 2:
-        raise ValueError("RES clean history must contain exactly video and audio streams")
-    video, audio = streams
+    if getattr(history, "is_nested", False):
+        streams = list(history.unbind())
+        if len(streams) != 2:
+            raise ValueError("RES clean history must contain exactly video and audio streams")
+        video, audio = streams
+    elif torch.is_tensor(history) and history.ndim == 3:
+        if not source_stream_shapes or len(source_stream_shapes) != 2:
+            raise ValueError(
+                "flat RES clean history needs the host pack's per-stream shapes"
+            )
+        shapes = [tuple(int(d) for d in shape) for shape in source_stream_shapes]
+        if sum(math.prod(s[1:]) for s in shapes) != history.shape[-1]:
+            raise ValueError(
+                "flat RES clean history does not match the recorded stream shapes"
+            )
+        cut = math.prod(shapes[0][1:])
+        video = history[:, :, :cut].reshape(shapes[0])
+        audio = history[:, :, cut:].reshape(shapes[1])
+    else:
+        raise ValueError(
+            "RES clean history must be a nested H3 video/audio pair or the "
+            "host's flat packed tensor"
+        )
     projected_video = spectral_expand_clean_3d(video, target_thw)
-    return type(history)([projected_video, audio])
+    if getattr(history, "is_nested", False):
+        return type(history)([projected_video, audio])
+    # Re-pack in the host pack_latents layout: [B, 1, N] slices concatenated
+    # on the last axis, so the rebased history is exactly the tensor shape
+    # the next host stage produces and consumes.
+    batch = projected_video.shape[0]
+    return torch.cat(
+        (
+            projected_video.reshape(batch, 1, -1),
+            audio.reshape(batch, 1, -1),
+        ),
+        dim=-1,
+    )
 
 
 def rebase_res_history_sigmas(
@@ -113,12 +171,13 @@ def res_multistep_sampler(
 ):
     """Run deterministic RES Multistep over ``sigmas``, carrying ``state``.
 
-    Matches the host ``KSAMPLER`` sampler-function contract: called as
+    Matches the host ``KSAMPLER`` sampler-FUNCTION contract: called as
     ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``
     where ``model(x, sigma, **extra_args)`` returns the denoised estimate
     and ``callback`` receives the native per-step dict. ``disable`` is
     accepted for contract compatibility; this implementation has no progress
-    bar of its own.
+    bar of its own. (The sampler-OBJECT contract is ``.sample`` on
+    :class:`ResMultistepSampler`; the two are not interchangeable.)
     """
     extra_args = {} if extra_args is None else extra_args
     x = noise
@@ -181,21 +240,52 @@ def res_multistep_sampler(
 
 
 class ResMultistepSampler:
-    """Host ``KSAMPLER``-compatible sampler object wrapping the stateful
-    RES function.
+    """Host sampler object wrapping the stateful RES function.
 
-    ``KSAMPLER`` invokes its sampler function as
-    ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``;
-    this object exposes exactly that call shape and always routes through
-    one shared ``ResMultistepState`` so the history survives every SPEED
-    stage call within the run.
+    The host guider invokes a sampler *object* as
+    ``sampler.sample(guider, sigmas, extra_args, callback, noise,
+    latent_image, denoise_mask, disable_pbar)`` (``CFGGuider.inner_sample``
+    wraps ``sampler.sample`` in its wrapper executor), which is the contract
+    native ``KSAMPLER`` objects implement. This class therefore wraps the
+    host's own ``KSAMPLER`` — constructed with :func:`res_multistep_sampler`
+    as its sampler function — and delegates ``.sample`` to it, so
+    ``noise_scaling``, the inpaint model wrapper, the per-step callback
+    adaptation, and ``inverse_noise_scaling`` all stay host-native (plan §13:
+    do not bypass ``guider.sample()``).
+
+    ``__call__`` is the separate sampler-*function* contract: it runs
+    :func:`res_multistep_sampler` directly on already-host-processed inputs,
+    as a plain ``KSAMPLER`` sampler function would receive them. The two
+    contracts are not interchangeable; only ``.sample`` satisfies the host
+    sampler-object seam.
     """
 
     def __init__(self, state: ResMultistepState | None = None):
         self.state = state if state is not None else ResMultistepState()
+        ksampler_cls = _host_ksampler_class()
+        if ksampler_cls is None:
+            raise RuntimeError(
+                "ResMultistepSampler requires the host comfy.samplers.KSAMPLER; "
+                "no real ComfyUI host is available in this environment"
+            )
+        self._ksampler = ksampler_cls(self._run)
 
-    def __call__(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
+    def _run(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
         return res_multistep_sampler(
             model, noise, sigmas, self.state,
+            extra_args=extra_args, callback=callback, disable=disable,
+        )
+
+    def sample(self, model_wrap, sigmas, extra_args, callback, noise,
+               latent_image=None, denoise_mask=None, disable_pbar=False):
+        return self._ksampler.sample(
+            model_wrap, sigmas, extra_args, callback, noise,
+            latent_image=latent_image, denoise_mask=denoise_mask,
+            disable_pbar=disable_pbar,
+        )
+
+    def __call__(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
+        return self._run(
+            model, noise, sigmas,
             extra_args=extra_args, callback=callback, disable=disable,
         )

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -1,0 +1,144 @@
+"""Stateful RES Multistep adapter for the SPEED pipeline.
+
+Deterministic, non-ancestral RES Multistep (``eta=0``): no noise injection,
+no SDE, no CFG++ path. Original implementation written from the published
+RES second-order multistep formulation (exponential integrators in
+``t = -ln(sigma)`` space). ComfyUI is used only as the behavioral reference
+for the host sampler-function contract — its solver source is never copied.
+
+Why this exists: the native ``res_multistep`` sampler keeps its step history
+in function locals, so every SPEED stage call would restart with empty
+history. Worse, the native code derives the previous input sigma from
+``sigmas[i - 1]``, which is the wrong element on the first step of a
+stage-local schedule. This adapter owns that history explicitly in a
+``ResMultistepState`` that the SPEED runtime carries across stages, and
+reads ``t_prev`` from the state instead of the schedule.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class ResMultistepState:
+    """Step history one RES run carries across SPEED stage boundaries.
+
+    ``old_denoised`` is the previous model denoised estimate, ``old_sigma_down``
+    the previous interval's destination sigma, and ``prev_sigma_in`` the
+    previous interval's input sigma. All three are written after every
+    completed interval; a single-sigma stage executes zero intervals and
+    leaves them untouched.
+    """
+
+    old_denoised: object | None = None
+    old_sigma_down: float | None = None
+    prev_sigma_in: float | None = None
+
+    def clear(self) -> None:
+        """Release every history reference (end-of-run cleanup)."""
+        self.old_denoised = None
+        self.old_sigma_down = None
+        self.prev_sigma_in = None
+
+
+def res_multistep_sampler(
+    model,
+    noise,
+    sigmas,
+    state: ResMultistepState,
+    extra_args=None,
+    callback=None,
+    disable=None,
+):
+    """Run deterministic RES Multistep over ``sigmas``, carrying ``state``.
+
+    Matches the host ``KSAMPLER`` sampler-function contract: called as
+    ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``
+    where ``model(x, sigma, **extra_args)`` returns the denoised estimate
+    and ``callback`` receives the native per-step dict. ``disable`` is
+    accepted for contract compatibility; this implementation has no progress
+    bar of its own.
+    """
+    extra_args = {} if extra_args is None else extra_args
+    x = noise
+    s_in = x.new_ones([x.shape[0]]) if torch.is_tensor(x) else 1.0
+
+    for i in range(len(sigmas) - 1):
+        sigma = sigmas[i]
+        denoised = model(x, sigma * s_in, **extra_args)
+        # Deterministic RES (eta=0): the destination sigma is the next
+        # schedule entry and no noise is ever added.
+        sigma_down = sigmas[i + 1]
+        if callback is not None:
+            callback({
+                "x": x, "i": i, "sigma": sigma, "sigma_hat": sigma,
+                "denoised": denoised,
+            })
+
+        sigma_f = float(sigma)
+        sigma_down_f = float(sigma_down)
+        old_denoised = state.old_denoised
+        old_sigma_down = state.old_sigma_down
+        prev_sigma_in = state.prev_sigma_in
+        # First order when the destination sigma is zero, when the carried
+        # history is missing, or when the interval is degenerate (zero width
+        # or a zero previous-step gap, which would divide by zero below).
+        # For every well-formed strictly decreasing schedule this reduces to
+        # the plan rule: first order iff destination sigma is zero or
+        # old_denoised is missing.
+        use_second_order = (
+            0.0 < sigma_down_f < sigma_f
+            and old_denoised is not None
+            and old_sigma_down is not None
+            and prev_sigma_in is not None
+            and old_sigma_down != prev_sigma_in
+        )
+        if use_second_order:
+            # Second order RES multistep: exponential integrators in
+            # t = -ln(sigma) space. t_prev comes from the carried state,
+            # never from sigmas[i - 1]: on the first step of a stage-local
+            # schedule that index is the wrong element.
+            t_old = -math.log(old_sigma_down)
+            t_next = -math.log(sigma_down_f)
+            t_prev = -math.log(prev_sigma_in)
+            h = t_next + math.log(sigma_f)
+            c2 = (t_prev - t_old) / h
+            phi1 = math.expm1(-h) / (-h)
+            phi2 = (phi1 - 1.0) / (-h)
+            b1 = 0.0 if math.isnan(phi1 - phi2 / c2) else phi1 - phi2 / c2
+            b2 = 0.0 if math.isnan(phi2 / c2) else phi2 / c2
+            x = math.exp(-h) * x + h * (b1 * denoised + b2 * old_denoised)
+        else:
+            # First order (Euler).
+            d = (x - denoised) / sigma
+            x = x + d * (sigma_down - sigma)
+
+        state.old_denoised = denoised
+        state.old_sigma_down = sigma_down_f
+        state.prev_sigma_in = sigma_f
+    return x
+
+
+class ResMultistepSampler:
+    """Host ``KSAMPLER``-compatible sampler object wrapping the stateful
+    RES function.
+
+    ``KSAMPLER`` invokes its sampler function as
+    ``fn(model, noise, sigmas, extra_args=..., callback=..., disable=...)``;
+    this object exposes exactly that call shape and always routes through
+    one shared ``ResMultistepState`` so the history survives every SPEED
+    stage call within the run.
+    """
+
+    def __init__(self, state: ResMultistepState | None = None):
+        self.state = state if state is not None else ResMultistepState()
+
+    def __call__(self, model, noise, sigmas, extra_args=None, callback=None, disable=None):
+        return res_multistep_sampler(
+            model, noise, sigmas, self.state,
+            extra_args=extra_args, callback=callback, disable=disable,
+        )

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -22,6 +22,9 @@ from dataclasses import dataclass
 
 import torch
 
+from .flow import aligned_sigma
+from .spectral import spectral_expand_clean_3d
+
 
 @dataclass
 class ResMultistepState:
@@ -43,6 +46,60 @@ class ResMultistepState:
         self.old_denoised = None
         self.old_sigma_down = None
         self.prev_sigma_in = None
+
+
+def project_clean_history(history, target_thw: tuple[int, int, int]):
+    """Project one clean RES history to the target video geometry.
+
+    ``history`` is the nested H3 denoised estimate (video ``[B,C,T,H,W]`` +
+    audio ``[B,C,2,T_audio]``) stored as solver history in
+    ``ResMultistepState.old_denoised``. Only the video geometry is projected,
+    with :func:`spectral_expand_clean_3d` — the estimate is clean solver
+    history, so it never receives fresh high-frequency noise and is never
+    scaled by sigma. The clean audio estimate is preserved unchanged and is
+    not sigma-reindexed: the boundary sigma belongs to the noisy re-entry
+    state, not to this history.
+    """
+    if not getattr(history, "is_nested", False):
+        raise ValueError("RES clean history must be a nested H3 video/audio pair")
+    streams = list(history.unbind())
+    if len(streams) != 2:
+        raise ValueError("RES clean history must contain exactly video and audio streams")
+    video, audio = streams
+    projected_video = spectral_expand_clean_3d(video, target_thw)
+    return type(history)([projected_video, audio])
+
+
+def rebase_res_history_sigmas(
+    state: ResMultistepState,
+    new_sigma: float,
+    ratio: float,
+) -> None:
+    """Rebase the sigma-history fields onto the aligned next-stage coordinates.
+
+    The RES history belongs to the old stage's coordinate system, but the next
+    sampler invocation starts at the aligned next-stage boundary. For
+    deterministic RES the previous step destination equals the boundary just
+    left, so ``old_sigma_down`` becomes ``new_sigma``. ``prev_sigma_in`` maps
+    through the same ``aligned_sigma`` scale-coordinate transform the SPEED
+    boundary itself uses. Empty fields stay empty. Mutates ``state`` in place;
+    never touches the scheduler or the working sigma schedule.
+    """
+    if state.old_sigma_down is not None:
+        state.old_sigma_down = float(new_sigma)
+    if state.prev_sigma_in is not None:
+        prev = float(state.prev_sigma_in)
+        if prev >= 1.0:
+            # Deviation from the plan's literal "call aligned_sigma": the
+            # shared transform rejects q >= 1, but an input sigma of 1.0 is
+            # legal history (the first interval of a stage that starts at
+            # pure noise). At q = 1 the transform's own formula gives
+            # kappa = ratio / ratio = 1, i.e. the identity, so the rebased
+            # value stays 1.0. Sigmas above 1 never occur in this repo's
+            # schedules and still fail closed through aligned_sigma.
+            state.prev_sigma_in = prev
+        else:
+            _, state.prev_sigma_in = aligned_sigma(prev, ratio)
 
 
 def res_multistep_sampler(

--- a/speed_scripts/res_multistep_adapter.py
+++ b/speed_scripts/res_multistep_adapter.py
@@ -89,14 +89,14 @@ def rebase_res_history_sigmas(
         state.old_sigma_down = float(new_sigma)
     if state.prev_sigma_in is not None:
         prev = float(state.prev_sigma_in)
-        if prev >= 1.0:
+        if prev == 1.0:
             # Deviation from the plan's literal "call aligned_sigma": the
-            # shared transform rejects q >= 1, but an input sigma of 1.0 is
-            # legal history (the first interval of a stage that starts at
-            # pure noise). At q = 1 the transform's own formula gives
+            # shared transform rejects q >= 1, but an input sigma of exactly
+            # 1.0 is legal history (the first interval of a stage that starts
+            # at pure noise). At q = 1 the transform's own formula gives
             # kappa = ratio / ratio = 1, i.e. the identity, so the rebased
-            # value stays 1.0. Sigmas above 1 never occur in this repo's
-            # schedules and still fail closed through aligned_sigma.
+            # value stays 1.0. Every other out-of-domain sigma (> 1 or <= 0)
+            # still fails closed through aligned_sigma.
             state.prev_sigma_in = prev
         else:
             _, state.prev_sigma_in = aligned_sigma(prev, ratio)

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -49,6 +49,12 @@ class SpeedTransition:
     Produced by the stage loop after the boundary sigma has been aligned and
     patched into the working schedule, and handed to the sampler handle's
     transition hook exactly once.
+
+    ``source_stream_shapes`` lists the per-stream latent shapes the stage's
+    sampler saw, in the host's flat-pack order (video first, then audio).
+    Stateless samplers ignore it; the stateful RES handle needs it to slice
+    a flat packed history tensor back into its video and audio streams,
+    because the host packs nested latents flat before any sampler code runs.
     """
 
     stage_idx: int
@@ -57,6 +63,7 @@ class SpeedTransition:
     new_sigma: float
     source_thw: tuple[int, int, int]
     target_thw: tuple[int, int, int]
+    source_stream_shapes: tuple[tuple[int, ...], tuple[int, ...]] | None = None
 
 
 class SpeedSamplerHandle:
@@ -122,11 +129,16 @@ class _ResMultistepSamplerHandle(SpeedSamplerHandle):
             return
         # Clean-history projection: replace the stored video geometry with the
         # clean spectral projection; the clean audio estimate passes through
-        # unchanged. Sigma metadata moves to the aligned next-stage coordinate
+        # unchanged. On the real host path the history is the flat packed
+        # tensor the guider produced at the sampler boundary, so the
+        # per-stream shapes from that pack ride along for the video/audio
+        # split. Sigma metadata moves to the aligned next-stage coordinate
         # system. Coincident boundaries simply run this again on the already
         # projected history; new history is never synthesized here.
         self.state.old_denoised = project_clean_history(
-            self.state.old_denoised, transition.target_thw
+            self.state.old_denoised,
+            transition.target_thw,
+            source_stream_shapes=transition.source_stream_shapes,
         )
         rebase_res_history_sigmas(
             self.state, transition.new_sigma, transition.ratio

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -110,6 +110,30 @@ class _ResMultistepSamplerHandle(SpeedSamplerHandle):
         self.sampler = ResMultistepSampler(self.state)
         self.capability = SamplerCapability.SINGLE_HISTORY
 
+    def on_transition(self, transition: SpeedTransition) -> None:
+        from .res_multistep_adapter import (
+            project_clean_history,
+            rebase_res_history_sigmas,
+        )
+
+        # No completed RES interval yet: nothing to project or rebase. The
+        # empty state is preserved as-is; no history is created here.
+        if self.state.old_denoised is None:
+            return
+        # Clean-history projection: replace the stored video geometry with the
+        # clean spectral projection; the clean audio estimate passes through
+        # unchanged. Sigma metadata moves to the aligned next-stage coordinate
+        # system. Coincident boundaries simply run this again on the already
+        # projected history; new history is never synthesized here.
+        self.state.old_denoised = project_clean_history(
+            self.state.old_denoised, transition.target_thw
+        )
+        rebase_res_history_sigmas(
+            self.state, transition.new_sigma, transition.ratio
+        )
+        # Deliberately untouched: the scheduler and working sigma schedule,
+        # the noisy re-entry tensors, and all H3 conditioning tensors.
+
     def close(self) -> None:
         self.state.clear()
 
@@ -129,7 +153,7 @@ def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
     return _StatelessSamplerHandle(sampler_name)
 
 
-def create_res_multistep_sampler_handle() -> SpeedSamplerHandle:
+def create_res_multistep_sampler_handle() -> "_ResMultistepSamplerHandle":
     """Build the run-scoped stateful RES handle (runtime-only seam).
 
     Not part of the public selector yet: ``res_multistep`` joins

--- a/speed_scripts/sampler_support.py
+++ b/speed_scripts/sampler_support.py
@@ -93,6 +93,27 @@ class _StatelessSamplerHandle(SpeedSamplerHandle):
         self.capability = SamplerCapability.STATELESS_STEP_LOCAL
 
 
+class _ResMultistepSamplerHandle(SpeedSamplerHandle):
+    """Run-scoped handle for the stateful RES Multistep adapter.
+
+    Owns one ``ResMultistepState`` per SPEED run. The wrapped sampler
+    object keeps that state across every stage's ``guider.sample()`` call,
+    so RES history survives stage boundaries; ``close()`` (run-level
+    cleanup) releases it. Never routes through the stage-resetting native
+    ``sampler_object("res_multistep")``.
+    """
+
+    def __init__(self):
+        from .res_multistep_adapter import ResMultistepSampler, ResMultistepState
+
+        self.state = ResMultistepState()
+        self.sampler = ResMultistepSampler(self.state)
+        self.capability = SamplerCapability.SINGLE_HISTORY
+
+    def close(self) -> None:
+        self.state.clear()
+
+
 def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
     """Build the run-scoped handle for ``sampler_name``.
 
@@ -106,3 +127,14 @@ def create_speed_sampler_handle(sampler_name: str) -> SpeedSamplerHandle:
             f"Supported samplers: {supported}."
         )
     return _StatelessSamplerHandle(sampler_name)
+
+
+def create_res_multistep_sampler_handle() -> SpeedSamplerHandle:
+    """Build the run-scoped stateful RES handle (runtime-only seam).
+
+    Not part of the public selector yet: ``res_multistep`` joins
+    ``SUPPORTED_SPEED_SAMPLERS`` only after the RES state-preservation
+    tests and real H3 validation pass (plan PR B acceptance). The runtime
+    reaches RES through this factory alone.
+    """
+    return _ResMultistepSamplerHandle()

--- a/speed_scripts/spectral.py
+++ b/speed_scripts/spectral.py
@@ -223,6 +223,42 @@ def spectral_expand_3d(
     return idct_temporal(idct2(dct_full)).to(dtype=original_dtype)
 
 
+def spectral_expand_clean_3d(
+    value: torch.Tensor,           # [..., T_coarse, H_coarse, W_coarse]
+    target_thw: tuple[int, int, int],
+) -> torch.Tensor:
+    """Clean-history 3D spectral projection: deterministic, no noise.
+
+    Input is a clean denoised estimate (solver history), not noisy state, so
+    the target's new high-frequency DCT coefficients are zero — never random.
+    Combined temporal + spatial DCT, zero-filled target coefficient tensor,
+    copy of the source low-frequency block, inverse combined DCT. Deterministic
+    and sigma-free by construction.
+    """
+    target_t, target_h, target_w = (int(target_thw[0]), int(target_thw[1]), int(target_thw[2]))
+    if value.ndim < 3:
+        raise ValueError("spectral_expand_clean_3d expects at least 3 dims")
+    source_t, source_h, source_w = value.shape[-3:]
+    if target_t < source_t or target_h < source_h or target_w < source_w:
+        raise ValueError(
+            f"3D DCT cannot expand {value.shape[-3:]} to {(target_t, target_h, target_w)}"
+        )
+
+    original_dtype = value.dtype
+    # Combined temporal+spatial DCT of the clean source. Same composition as
+    # spectral_expand_3d: the two transforms act on disjoint axes, so the
+    # order is irrelevant.
+    source_dct = dct2(dct_temporal(value))
+    target_dct = torch.zeros(
+        value.shape[:-3] + (target_t, target_h, target_w),
+        device=value.device,
+        dtype=source_dct.dtype,
+    )
+    target_dct[..., :source_t, :source_h, :source_w] = source_dct
+    return idct_temporal(idct2(target_dct)).to(dtype=original_dtype)
+
+
 __all__ = ["dct2", "idct2", "lowpass_dct", "lowpass_filter",
            "spectral_expand", "spectral_expand_coupled",
-           "dct_temporal", "idct_temporal", "spectral_expand_3d"]
+           "dct_temporal", "idct_temporal", "spectral_expand_3d",
+           "spectral_expand_clean_3d"]

--- a/speed_scripts/tests/test_res_host_seam.py
+++ b/speed_scripts/tests/test_res_host_seam.py
@@ -1,0 +1,340 @@
+"""Host-seam tests for the RES Multistep adapter (plan S7 §13).
+
+These tests exercise the two seams the real ComfyUI host builds and the
+earlier runtime tests bypassed:
+
+1. The sampler-OBJECT contract. The host ``CFGGuider.inner_sample`` wraps
+   ``sampler.sample`` in its wrapper executor and calls
+   ``executor.execute(self, sigmas, extra_args, callback, noise,
+   latent_image, denoise_mask, disable_pbar)`` — the object must expose
+   ``.sample`` with that shape. A guider here invokes the sampler object
+   exactly that way.
+
+2. The flat packed tensor at the sampler boundary. On a real nested-latent
+   H3 run, ``CFGGuider.sample`` packs video+audio FLAT with
+   ``comfy.utils.pack_latents`` (each stream reshaped ``[B, 1, -1]``,
+   concatenated on the last axis) before any sampler code runs, and unpacks
+   the sampler output back into a nested tensor afterwards. So the model's
+   denoised output at the boundary — and therefore the RES history stored in
+   ``ResMultistepState.old_denoised`` — is a plain flat tensor, and the
+   ``on_transition`` history projection must split video from audio without
+   crashing.
+
+The conftest ``KSAMPLER`` stub models the host shape; these tests use it the
+way ``CFGGuider`` uses the real one.
+"""
+
+import math
+
+import pytest
+import torch
+
+import speed_scripts.h3_runtime as h3_runtime
+from conftest import (
+    LADDER_BOUNDARIES,
+    SeededRandomNoise,
+    make_latent,
+)
+from speed_scripts.automatic_config import STAGES_TO_SCALES
+from speed_scripts.config import SpeedConfig
+from speed_scripts.h3_runtime import _LW_ATTR, run_speed_pipeline
+from speed_scripts.res_multistep_adapter import (
+    ResMultistepSampler,
+    ResMultistepState,
+)
+from speed_scripts.sampler_support import (
+    SpeedTransition,
+    create_res_multistep_sampler_handle,
+)
+
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# Host-shaped helpers
+# ---------------------------------------------------------------------------
+
+def _pack_latents(streams):
+    """The host ``comfy.utils.pack_latents`` layout, verbatim."""
+    shapes, tensors = [], []
+    for tensor in streams:
+        shapes.append(tuple(tensor.shape))
+        tensors.append(tensor.reshape(tensor.shape[0], 1, -1))
+    return torch.cat(tensors, dim=-1), shapes
+
+
+def _unpack_latents(combined, shapes):
+    """The host ``comfy.utils.unpack_latents`` layout, verbatim."""
+    out, work = [], combined
+    for shape in shapes:
+        cut = math.prod(shape[1:])
+        out.append(work[:, :, :cut].reshape([work.shape[0]] + list(shape)[1:]))
+        work = work[:, :, cut:]
+    return out
+
+
+class HostShapedGuider:
+    """A guider with the real host CFGGuider calling conventions.
+
+    ``sample`` packs nested noise + latent flat, then invokes the sampler
+    object through the host sampler-object contract: a WrapperExecutor-style
+    ``getattr(sampler, "sample")`` lookup followed by the positional call
+    ``sampler.sample(self, sigmas, extra_args, callback, noise, latent_image,
+    denoise_mask, disable_pbar)``. The model callable is the host's
+    ``KSamplerX0Inpaint`` shape (inner call receives only
+    ``(x, sigma, model_options, seed)``). The sampler output is unpacked back
+    into a nested pair, like ``CFGGuider.sample`` does. Records the sampler
+    objects it saw and the state snapshot at each stage entry.
+
+    Carries ``model_patcher.model`` with the sigma-shift attributes the
+    SPEED runtime resolves from the guider, like the real host guider does.
+    """
+
+    class _Model:
+        sigma_shift_video = 12.0
+        sigma_shift_audio = 3.0
+
+        def process_latent_out(self, x):
+            return x
+
+    def __init__(self):
+        self.model_patcher = type("P", (), {"model": self._Model()})()
+        self.samplers = []
+        self.sigma_calls = []
+        self.stage_entries = []
+        self.model_evals = 0
+        # Per-stream shapes of the most recent stage's nested latent (the
+        # layout the model call must slice, set fresh by every sample() call).
+        self.stream_shapes = [(1, 1, 2, 4, 4), (1, 1, 2, 8)]
+
+    def __call__(self, x, sigma, denoise_mask=None, model_options=None, seed=None):
+        # CFGGuider shape: the guider itself is the model wrapper KSAMPLER
+        # wraps; its call produces the denoised prediction for the flat pack.
+        # The prediction covers the same flat layout, so the video and audio
+        # slices are transformed separately, like the real H3 model does.
+        self.model_evals += 1
+        s = float(sigma)
+        video_elems = math.prod(self.stream_shapes[0][1:])
+        video, audio = x[:, :, :video_elems], x[:, :, video_elems:]
+        video = video * 0.7 + 0.3 * (s / (1.0 + s))
+        audio = audio * 0.8 + 0.02 * (s / (1.0 + s))
+        return torch.cat(
+            (video.reshape(x.shape[0], 1, -1), audio.reshape(x.shape[0], 1, -1)),
+            dim=-1,
+        )
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        self.sigma_calls.append([float(s) for s in sigmas])
+        nested_streams = list(latent_image.unbind())
+        self.stream_shapes = [tuple(t.shape) for t in nested_streams]
+        noise_flat, _ = _pack_latents(list(noise.unbind()))
+        latent_flat, _ = _pack_latents(nested_streams)
+        state = getattr(sampler, "state", None)
+        if state is not None and state.old_denoised is not None:
+            self.stage_entries.append(_FlatSnapshot(state))
+        else:
+            self.stage_entries.append(None)
+        count = len(sigmas) - 1
+
+        def host_callback(step, x0, x, total_steps):
+            if callback is not None:
+                callback(step, x0, x, total_steps)
+
+        # The exact host invocation: sampler.sample(guider, sigmas,
+        # extra_args, callback, noise, latent_image, denoise_mask, pbar).
+        out_flat = sampler.sample(
+            self, sigmas, {}, host_callback, noise_flat,
+            latent_image=latent_flat, denoise_mask=None, disable_pbar=True,
+        )
+        video, audio = _unpack_latents(
+            out_flat, [tuple(t.shape) for t in latent_image.unbind()]
+        )
+        from conftest import make_nested
+        return make_nested(video, audio)
+
+
+class _FlatSnapshot:
+    """What the run-scoped RES state held when one stage began (flat path)."""
+
+    def __init__(self, state):
+        self.old_denoised = state.old_denoised
+        self.old_sigma_down = state.old_sigma_down
+        self.prev_sigma_in = state.prev_sigma_in
+
+
+def _flat_ladder_cfg(stages, **overrides):
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=LADDER_BOUNDARIES[stages],
+        transition_mode="explicit",
+        audio_policy="carry_preserve",
+        **overrides,
+    )
+
+
+def _run_flat_host(cfg, guider, monkeypatch):
+    handle = create_res_multistep_sampler_handle()
+    captured = []
+
+    def factory(name):
+        captured.append((name, handle))
+        return handle
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", factory)
+    out, denoised = run_speed_pipeline(
+        SeededRandomNoise(), guider, SIGMAS, make_latent(), cfg,
+        sampler_name="res_multistep", disable_pbar=True,
+    )
+    assert captured == [("res_multistep", handle)]
+    return handle, out, denoised
+
+
+# ---------------------------------------------------------------------------
+# Critical 1: the host sampler-object contract (.sample)
+# ---------------------------------------------------------------------------
+
+def test_res_sampler_object_exposes_host_sample_contract():
+    """The attribute the host resolves is ``.sample`` (WrapperExecutor wraps
+    ``sampler.sample``), with the host's positional shape."""
+    sampler = ResMultistepSampler()
+    assert hasattr(sampler, "sample")
+    import inspect
+    params = [p for p in inspect.signature(sampler.sample).parameters if p != "self"]
+    assert params == [
+        "model_wrap", "sigmas", "extra_args", "callback", "noise",
+        "latent_image", "denoise_mask", "disable_pbar",
+    ]
+
+
+def test_host_shaped_sample_call_runs_and_preserves_state():
+    """A host-shaped ``.sample`` call runs the real stateful RES function and
+    routes through the same state object a follow-up call sees. The guider
+    doubles as the model callable (``KSamplerX0Inpaint`` wraps the guider's
+    model, which the wrapper invokes with only ``(x, sigma, ...)``)."""
+    sampler = ResMultistepSampler()
+    seen = []
+
+    def model(x, sigma, denoise_mask=None, model_options=None, seed=None):
+        seen.append(sigma)
+        return x * 0.7
+
+    noise_video = torch.randn(1, 1, 2, 4, 4)
+    noise_audio = torch.randn(1, 1, 2, 8)
+    noise_flat, _ = _pack_latents([noise_video, noise_audio])
+    latent_flat, _ = _pack_latents([
+        torch.zeros_like(noise_video), torch.zeros_like(noise_audio)
+    ])
+    out = sampler.sample(
+        model, SIGMAS[:5], {}, None, noise_flat,
+        latent_image=latent_flat, denoise_mask=None, disable_pbar=True,
+    )
+    assert out.shape == noise_flat.shape
+    # Four intervals, each evaluated once, with the denoise_mask contract the
+    # host KSAMPLER injects into extra_args.
+    assert len(seen) == 4
+    # History was written by the run and is the host's flat tensor shape.
+    assert sampler.state.old_denoised is not None
+    assert torch.is_tensor(sampler.state.old_denoised)
+    assert sampler.state.old_denoised.shape == noise_flat.shape
+    assert sampler.state.old_sigma_down == pytest.approx(0.6)
+    assert sampler.state.prev_sigma_in == pytest.approx(0.7)
+    # A second host-shaped call carries the same state forward.
+    out2 = sampler.sample(
+        model, SIGMAS[4:], {}, None, noise_flat,
+        latent_image=latent_flat, denoise_mask=None, disable_pbar=True,
+    )
+    assert out2.shape == out.shape
+    # 4 intervals in the first call, 6 in the second.
+    assert len(seen) == 10
+
+
+def test_res_multistep_state_clear_releases_history():
+    state = ResMultistepState()
+    state.old_denoised = torch.zeros(1, 1, 4)
+    state.old_sigma_down = 0.5
+    state.prev_sigma_in = 0.7
+    state.clear()
+    assert state.old_denoised is None
+    assert state.old_sigma_down is None
+    assert state.prev_sigma_in is None
+
+
+# ---------------------------------------------------------------------------
+# Critical 2: flat packed history at the sampler boundary
+# ---------------------------------------------------------------------------
+
+def test_flat_history_on_transition_projects_video_and_preserves_audio():
+    """A flat packed history (the only shape the real host produces at the
+    sampler boundary) is projected without crashing: video geometry advances,
+    audio elements pass through bit-exact, and the result re-packs flat."""
+    video = torch.arange(16, dtype=torch.float32).reshape(1, 1, 2, 2, 4) / 16
+    audio = torch.arange(8, dtype=torch.float32).reshape(1, 1, 2, 4) / 8
+    flat, shapes = _pack_latents([video, audio])
+    handle = create_res_multistep_sampler_handle()
+    handle.state.old_denoised = flat
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.7
+    handle.on_transition(SpeedTransition(
+        stage_idx=0, ratio=2.0, old_sigma=0.5, new_sigma=0.4,
+        source_thw=(2, 2, 4), target_thw=(2, 4, 8),
+        source_stream_shapes=shapes,
+    ))
+    projected = handle.state.old_denoised
+    assert torch.is_tensor(projected)
+    # Target geometry (1, 1, 2, 4, 8) = 64 video elems + 8 audio elems.
+    assert projected.shape == (1, 1, 72)
+    p_video, p_audio = _unpack_latents(
+        projected, [(1, 1, 2, 4, 8), (1, 1, 2, 4)]
+    )
+    assert tuple(p_video.shape[-3:]) == (2, 4, 8)
+    # Audio is preserved bit-exact through the projection.
+    assert torch.equal(p_audio, audio)
+    # Sigma metadata was rebased onto the aligned coordinates.
+    assert handle.state.old_sigma_down == pytest.approx(0.4)
+
+
+def test_flat_history_on_transition_requires_stream_shapes():
+    """A flat history without the pack's shapes fails closed instead of
+    guessing a slice boundary."""
+    handle = create_res_multistep_sampler_handle()
+    handle.state.old_denoised = torch.zeros(1, 1, 40)
+    with pytest.raises(ValueError, match="per-stream shapes"):
+        handle.on_transition(SpeedTransition(
+            stage_idx=0, ratio=2.0, old_sigma=0.5, new_sigma=0.4,
+            source_thw=(2, 2, 4), target_thw=(2, 4, 4),
+        ))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a CFGGuider-shaped guider through the real runtime
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3))
+def test_runtime_with_cfgguider_shaped_guider_completes(monkeypatch, stages):
+    """Full run with the guider shaped like the real host ``CFGGuider``:
+    nested in the runtime's hands, flat at the sampler boundary, sampler
+    invoked via ``.sample``. Both criticals crashed exactly here before the
+    fix — no ``.sample`` attribute, then ValueError at the first transition."""
+    guider = HostShapedGuider()
+    handle, out, denoised = _run_flat_host(_flat_ladder_cfg(stages), guider, monkeypatch)
+
+    assert len(guider.sigma_calls) == stages
+    assert guider.model_evals == len(SIGMAS) - 1
+    # Every stage received the SAME run-scoped sampler object.
+    assert guider.samplers == [guider.samplers[0]] * stages
+    assert isinstance(guider.samplers[0], ResMultistepSampler)
+    video, audio = out["samples"].unbind()
+    assert tuple(video.shape[-2:]) == (8, 8)
+    assert audio.ndim == 4
+    # Stage entries: stage 0 empty; later stages carry flat packed history.
+    assert guider.stage_entries[0] is None
+    for snap in guider.stage_entries[1:]:
+        assert snap is not None
+        assert torch.is_tensor(snap.old_denoised)
+        assert snap.old_denoised.ndim == 3  # the host's flat pack
+    # Run-level cleanup ran.
+    assert not hasattr(guider, _LW_ATTR)
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None

--- a/speed_scripts/tests/test_res_multistep_adapter.py
+++ b/speed_scripts/tests/test_res_multistep_adapter.py
@@ -1,0 +1,283 @@
+"""RES Multistep adapter: state model, deterministic pipeline, and the
+same-resolution split oracle (plan S7 §11-§15).
+
+The oracle is the gate for this slice: one uninterrupted deterministic RES
+trajectory over a fixed sigma schedule must land exactly where the same
+schedule does when it is split at a valid interior boundary and the
+``ResMultistepState`` is carried across the split. Splitting must change
+nothing numerically. Three targeted mutations of the carried history
+(discarding ``old_denoised``, ``old_sigma_down``, or ``prev_sigma_in`` at
+the split) must each break the match — that is what makes the test sensitive
+to the state the SPEED stage loop has to preserve. The negative control
+pins the other side: clearing the state at the split must produce a
+different trajectory.
+
+Everything here runs against a deterministic fake model on plain float
+schedules — no ComfyUI import is needed below the handle seam.
+"""
+
+import torch
+import pytest
+
+from speed_scripts.res_multistep_adapter import (
+    ResMultistepSampler,
+    ResMultistepState,
+    res_multistep_sampler,
+)
+from speed_scripts.sampler_support import (
+    STATELESS_SPEED_SAMPLERS,
+    SUPPORTED_SPEED_SAMPLERS,
+    SamplerCapability,
+    _ResMultistepSamplerHandle,
+    create_res_multistep_sampler_handle,
+    create_speed_sampler_handle,
+)
+
+#: Fixed strictly decreasing schedule; the trailing zero is the clean point.
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+#: Plan S7 §15: "tight numeric tolerance". The split changes nothing, so the
+#: two runs must agree to float-epsilon level on these small tensors.
+TOLERANCE = 1e-6
+
+#: Interior boundary used by the split oracle: both segments carry real
+#: RES intervals, so the carried history is exercised at the seam.
+SPLIT_INDEX = 4
+
+
+class DeterministicModel:
+    """Smooth, deterministic stand-in for the diffusion model.
+
+    A fixed linear map of ``x`` blended with a sigma-dependent direction:
+    cheap, deterministic, and nonlinear enough that first-order and
+    second-order RES steps disagree numerically (the oracle's mutation
+    sensitivity depends on that disagreement).
+    """
+
+    def __init__(self, channels=3, seed=7):
+        g = torch.Generator().manual_seed(seed)
+        self.a = torch.randn(channels, generator=g).reshape(1, channels, 1, 1)
+        self.b = torch.randn(channels, generator=g).reshape(1, channels, 1, 1)
+
+    def __call__(self, x, sigma, **kwargs):
+        s = float(sigma)
+        return self.a * x + self.b * (s / (1.0 + s))
+
+
+class CallbackLog:
+    """Records the native per-step callback dicts."""
+
+    def __init__(self):
+        self.entries = []
+
+    def __call__(self, entry):
+        self.entries.append(entry)
+
+
+def _run(samplers_args):
+    """Run RES over consecutive schedule segments, one sampler call each.
+
+    ``samplers_args`` is a list of ``(sigmas, state, clear_first)`` tuples.
+    Returns ``(final_x, states, callbacks)``.
+    """
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4, generator=torch.Generator().manual_seed(123))
+    states, callbacks = [], []
+    for sigmas, state, clear_first in samplers_args:
+        if clear_first:
+            state.clear()
+        log = CallbackLog()
+        x = res_multistep_sampler(
+            model, x, sigmas, state, callback=log, disable=True,
+        )
+        states.append(state)
+        callbacks.append(log)
+    return x, states, callbacks
+
+
+def _split_segment(sigmas, start, end):
+    """Slice ``sigmas[start : end]`` as one stage-local segment."""
+    return sigmas[start:end]
+
+
+# ---------------------------------------------------------------------------
+# State object (plan S7 §12)
+# ---------------------------------------------------------------------------
+
+def test_state_starts_empty_and_clear_releases_everything():
+    state = ResMultistepState()
+    assert state.old_denoised is None
+    assert state.old_sigma_down is None
+    assert state.prev_sigma_in is None
+    tensor = torch.zeros(2, 2)
+    state.old_denoised = tensor
+    state.old_sigma_down = 0.5
+    state.prev_sigma_in = 0.9
+    state.clear()
+    assert state.old_denoised is None
+    assert state.old_sigma_down is None
+    assert state.prev_sigma_in is None
+
+
+def test_single_sigma_stage_executes_zero_intervals_and_touches_nothing():
+    """A one-entry schedule has zero intervals: no model call, no callback,
+    no state write, input returned unchanged."""
+    state = ResMultistepState()
+    state.old_denoised = torch.ones(1, 3, 4, 4)
+    state.old_sigma_down = 0.4
+    state.prev_sigma_in = 0.6
+    x = torch.randn(1, 3, 4, 4)
+    model = DeterministicModel()
+    calls = []
+
+    def counting_model(*args, **kwargs):
+        calls.append(1)
+        return model(*args, **kwargs)
+
+    out = res_multistep_sampler(
+        counting_model, x, torch.tensor([0.5]), state, disable=True,
+    )
+    assert calls == []
+    assert out is x
+    assert state.old_denoised is not None
+    assert state.old_sigma_down == pytest.approx(0.4)
+    assert state.prev_sigma_in == pytest.approx(0.6)
+
+
+def test_final_zero_sigma_interval_uses_first_order_and_updates_state():
+    """The last interval lands on sigma 0: it must take the first-order
+    path (no -log(0)) and still update all three history fields."""
+    state = ResMultistepState()
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4)
+    out = res_multistep_sampler(
+        model, x, torch.tensor([0.3, 0.0]), state, disable=True,
+    )
+    assert torch.isfinite(out).all()
+    assert state.old_denoised is not None
+    assert state.old_sigma_down == 0.0
+    assert state.prev_sigma_in == pytest.approx(0.3)
+
+
+def test_sampler_object_shares_one_state_across_calls():
+    """The KSAMPLER-compatible wrapper routes every call through the same
+    state object, so history survives separate invocations."""
+    sampler = ResMultistepSampler()
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4)
+    x = sampler(model, x, SIGMAS[: SPLIT_INDEX + 1], disable=True)
+    state_after_first = (
+        sampler.state.old_sigma_down, sampler.state.prev_sigma_in,
+    )
+    x = sampler(model, x, SIGMAS[SPLIT_INDEX:], disable=True)
+    # Last completed interval of the first segment: 0.7 -> 0.6.
+    assert state_after_first == pytest.approx((0.6, 0.7))
+    assert sampler.state.old_sigma_down == 0.0
+    assert sampler.state.prev_sigma_in == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# Same-resolution split oracle (plan S7 §15)
+# ---------------------------------------------------------------------------
+
+def test_split_with_carried_state_matches_uninterrupted_run():
+    """Split the schedule at an interior boundary and carry the state:
+    the final x and the full history trajectory must match the
+    uninterrupted run within tight tolerance."""
+    full_x, full_states, full_cbs = _run([(SIGMAS, ResMultistepState(), False)])
+
+    state = ResMultistepState()
+    split_x, split_states, split_cbs = _run([
+        (_split_segment(SIGMAS, 0, SPLIT_INDEX + 1), state, False),
+        (_split_segment(SIGMAS, SPLIT_INDEX, len(SIGMAS)), state, False),
+    ])
+
+    assert torch.allclose(full_x, split_x, atol=TOLERANCE, rtol=0.0)
+    # The whole trajectory, not just the endpoint: per-step callback payloads
+    # must line up one-to-one.
+    assert len(full_cbs[0].entries) == len(SIGMAS) - 1
+    assert len(split_cbs[0].entries) + len(split_cbs[1].entries) == len(SIGMAS) - 1
+    for a, b in zip(
+        full_cbs[0].entries,
+        split_cbs[0].entries + split_cbs[1].entries,
+    ):
+        assert torch.allclose(a["x"], b["x"], atol=TOLERANCE, rtol=0.0)
+        assert torch.allclose(a["denoised"], b["denoised"], atol=TOLERANCE, rtol=0.0)
+    # Carried state converges to the same terminal history.
+    assert full_states[0].old_sigma_down == split_states[-1].old_sigma_down
+    assert full_states[0].prev_sigma_in == split_states[-1].prev_sigma_in
+    assert torch.allclose(
+        full_states[0].old_denoised, split_states[-1].old_denoised,
+        atol=TOLERANCE, rtol=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutation sensitivity: each discarded field must break the match
+# ---------------------------------------------------------------------------
+
+def _split_discarding(discard):
+    """Run the split oracle but drop one history field at the split."""
+    state = ResMultistepState()
+    _run([(_split_segment(SIGMAS, 0, SPLIT_INDEX + 1), state, False)])
+    if discard == "old_denoised":
+        state.old_denoised = None
+    elif discard == "old_sigma_down":
+        state.old_sigma_down = None
+    elif discard == "prev_sigma_in":
+        state.prev_sigma_in = None
+    x, _, _ = _run([(_split_segment(SIGMAS, SPLIT_INDEX, len(SIGMAS)), state, False)])
+    return x
+
+
+@pytest.mark.parametrize("field", ["old_denoised", "old_sigma_down", "prev_sigma_in"])
+def test_oracle_fails_when_a_history_field_is_discarded(field):
+    full_x, _, _ = _run([(SIGMAS, ResMultistepState(), False)])
+    mutated_x = _split_discarding(field)
+    assert not torch.allclose(full_x, mutated_x, atol=TOLERANCE, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Negative control (plan S7 §15)
+# ---------------------------------------------------------------------------
+
+def test_clearing_state_at_the_split_produces_a_different_result():
+    full_x, _, _ = _run([(SIGMAS, ResMultistepState(), False)])
+    state = ResMultistepState()
+    reset_x, _, _ = _run([
+        (_split_segment(SIGMAS, 0, SPLIT_INDEX + 1), state, False),
+        (_split_segment(SIGMAS, SPLIT_INDEX, len(SIGMAS)), state, True),
+    ])
+    assert not torch.allclose(full_x, reset_x, atol=TOLERANCE, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Handle seam (plan S7 §5/§13; public selector stays PR A)
+# ---------------------------------------------------------------------------
+
+def test_res_handle_keeps_single_history_and_clears_on_close():
+    handle = create_res_multistep_sampler_handle()
+    assert isinstance(handle, _ResMultistepSamplerHandle)
+    assert handle.capability is SamplerCapability.SINGLE_HISTORY
+    assert isinstance(handle.sampler, ResMultistepSampler)
+    assert handle.state is handle.sampler.state
+    # History actually lands in the run-scoped state.
+    model = DeterministicModel()
+    x = torch.randn(1, 3, 4, 4)
+    handle.sampler(model, x, SIGMAS[: SPLIT_INDEX + 1], disable=True)
+    assert handle.state.old_denoised is not None
+    handle.close()
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None
+
+
+def test_public_selector_still_excludes_res_multistep():
+    assert SUPPORTED_SPEED_SAMPLERS == STATELESS_SPEED_SAMPLERS
+    assert "res_multistep" not in SUPPORTED_SPEED_SAMPLERS
+
+
+def test_public_factory_still_rejects_res_multistep_fail_closed():
+    with pytest.raises(ValueError) as excinfo:
+        create_speed_sampler_handle("res_multistep")
+    assert "res_multistep" in str(excinfo.value)

--- a/speed_scripts/tests/test_res_multistep_adapter.py
+++ b/speed_scripts/tests/test_res_multistep_adapter.py
@@ -1,5 +1,6 @@
-"""RES Multistep adapter: state model, deterministic pipeline, and the
-same-resolution split oracle (plan S7 §11-§15).
+"""RES Multistep adapter: state model, deterministic pipeline, the
+same-resolution split oracle (plan S7 §11-§15), and the transition slice
+(clean history projection, sigma rebase, ``on_transition`` — plan S7 §16-§19).
 
 The oracle is the gate for this slice: one uninterrupted deterministic RES
 trajectory over a fixed sigma schedule must land exactly where the same
@@ -12,6 +13,13 @@ to the state the SPEED stage loop has to preserve. The negative control
 pins the other side: clearing the state at the split must produce a
 different trajectory.
 
+The transition oracles pin plan §16-§18: clean history projection adds zero
+high-frequency content and never touches clean audio; sigma metadata is
+rebased onto the aligned next-stage coordinates; coincident boundaries
+re-project and re-rebase without ever creating new history. Each oracle
+computes its expected values independently so it can fail if the property
+breaks.
+
 Everything here runs against a deterministic fake model on plain float
 schedules — no ComfyUI import is needed below the handle seam.
 """
@@ -19,19 +27,24 @@ schedules — no ComfyUI import is needed below the handle seam.
 import torch
 import pytest
 
+from speed_scripts.flow import aligned_sigma
 from speed_scripts.res_multistep_adapter import (
     ResMultistepSampler,
     ResMultistepState,
+    project_clean_history,
+    rebase_res_history_sigmas,
     res_multistep_sampler,
 )
 from speed_scripts.sampler_support import (
     STATELESS_SPEED_SAMPLERS,
     SUPPORTED_SPEED_SAMPLERS,
     SamplerCapability,
+    SpeedTransition,
     _ResMultistepSamplerHandle,
     create_res_multistep_sampler_handle,
     create_speed_sampler_handle,
 )
+from speed_scripts.spectral import dct2, dct_temporal, spectral_expand_clean_3d
 
 #: Fixed strictly decreasing schedule; the trailing zero is the clean point.
 SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
@@ -281,3 +294,214 @@ def test_public_factory_still_rejects_res_multistep_fail_closed():
     with pytest.raises(ValueError) as excinfo:
         create_speed_sampler_handle("res_multistep")
     assert "res_multistep" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Clean projection primitive (plan S7 §16, §31 step 35)
+# ---------------------------------------------------------------------------
+
+class _Nested:
+    """Minimal nested H3 stand-in: video [B,C,T,H,W] + audio [B,C,2,T_audio].
+
+    Mirrors the real ``NestedTensor`` constructor contract — one list of
+    streams — so ``type(history)([video, audio])`` in the adapter rebuilds
+    the same shape.
+    """
+
+    def __init__(self, streams):
+        self.streams = list(streams)
+        self.is_nested = True
+
+    def unbind(self):
+        return list(self.streams)
+
+
+def _known_video(t=2, h=4, w=4, channels=1, batch=1, seed=99):
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(batch, channels, t, h, w, generator=g)
+
+
+def _known_audio(t_audio=6, channels=1, batch=1, seed=123):
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(batch, channels, 2, t_audio, generator=g)
+
+
+def test_clean_projection_copies_low_band_and_zeroes_high_band():
+    """Round-trip property: the target's combined DCT equals the source's
+    block embedded in an all-zero target tensor. Any random high-frequency
+    content or sigma scaling would break this by orders of magnitude."""
+    source = _known_video()
+    source_dct = dct2(dct_temporal(source))
+    target = spectral_expand_clean_3d(source, (3, 6, 6))
+    expected_dct = torch.zeros(1, 1, 3, 6, 6)
+    expected_dct[..., :2, :4, :4] = source_dct
+    assert torch.allclose(
+        dct2(dct_temporal(target)), expected_dct, atol=1e-5, rtol=0.0,
+    )
+
+
+def test_clean_projection_is_deterministic_and_shape_exact():
+    """No randomness anywhere: two calls agree bit-for-bit, and an exact-shape
+    call reconstructs the input (zero-filled new space is empty)."""
+    source = _known_video()
+    first = spectral_expand_clean_3d(source, (3, 6, 6))
+    second = spectral_expand_clean_3d(source, (3, 6, 6))
+    assert torch.equal(first, second)
+    assert first.shape == (1, 1, 3, 6, 6)
+    exact = spectral_expand_clean_3d(source, (2, 4, 4))
+    assert torch.allclose(exact, source, atol=1e-5, rtol=0.0)
+
+
+def test_clean_projection_preserves_dtype_and_rejects_shrinking():
+    source16 = _known_video().to(dtype=torch.float16)
+    out16 = spectral_expand_clean_3d(source16, (3, 6, 6))
+    assert out16.dtype == torch.float16
+    with pytest.raises(ValueError):
+        spectral_expand_clean_3d(_known_video(t=4, h=6, w=6), (2, 4, 4))
+
+
+def test_clean_history_projection_video_moves_audio_untouched():
+    """Nested H3 history: video geometry grows, the clean audio estimate is
+    numerically unchanged and stays a nested video/audio pair."""
+    video, audio = _known_video(), _known_audio()
+    history = _Nested([video, audio])
+    projected = project_clean_history(history, (4, 8, 8))
+    assert getattr(projected, "is_nested", False)
+    p_video, p_audio = projected.unbind()
+    assert p_video.shape == (1, 1, 4, 8, 8)
+    assert p_audio is audio
+    assert not torch.equal(p_video, video)
+    assert torch.allclose(
+        dct2(dct_temporal(p_video))[..., :2, :4, :4],
+        dct2(dct_temporal(video)),
+        atol=1e-5, rtol=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sigma rebase (plan S7 §17, §31 step 38)
+# ---------------------------------------------------------------------------
+
+def test_rebase_sigmas_sets_destination_and_aligns_prev_input():
+    """Independent expected values: old_sigma_down becomes the aligned
+    boundary sigma; prev_sigma_in maps through aligned_sigma with the same
+    ratio. Empty fields stay empty."""
+    state = ResMultistepState(
+        old_sigma_down=0.42, prev_sigma_in=0.68,
+    )
+    new_q = 0.25
+    ratio = 2.0
+    expected_prev = aligned_sigma(0.68, ratio)[1]
+    rebase_res_history_sigmas(state, new_q, ratio)
+    assert state.old_sigma_down == pytest.approx(new_q)
+    assert state.prev_sigma_in == pytest.approx(expected_prev)
+
+    partial = ResMultistepState(old_sigma_down=0.3)
+    rebase_res_history_sigmas(partial, new_q, ratio)
+    assert partial.old_sigma_down == pytest.approx(new_q)
+    assert partial.prev_sigma_in is None
+
+
+def test_rebase_sigmas_keeps_input_sigma_of_one():
+    """History may legitimately hold prev_sigma_in = 1.0 (a stage starting at
+    pure noise). aligned_sigma rejects q >= 1, but its own formula is the
+    identity there, so the rebased value must stay 1.0 instead of raising."""
+    state = ResMultistepState(old_sigma_down=0.5, prev_sigma_in=1.0)
+    rebase_res_history_sigmas(state, 0.25, 2.0)
+    assert state.old_sigma_down == pytest.approx(0.25)
+    assert state.prev_sigma_in == pytest.approx(1.0)
+
+
+def test_rebase_sigmas_never_mutates_scheduler_data():
+    """The rebase is metadata-only: the caller's schedule tensor must come
+    out byte-identical."""
+    schedule = torch.tensor([1.0, 0.9, 0.5, 0.25, 0.0])
+    snapshot = schedule.clone()
+    state = ResMultistepState(old_sigma_down=0.5, prev_sigma_in=0.9)
+    rebase_res_history_sigmas(state, float(schedule[3]), 1.5)
+    assert torch.equal(schedule, snapshot)
+
+
+# ---------------------------------------------------------------------------
+# on_transition handle hook (plan S7 §18, §31 steps 39-41)
+# ---------------------------------------------------------------------------
+
+def _transition(source_thw, target_thw, ratio=2.0, old_sigma=0.5, stage_idx=0):
+    return SpeedTransition(
+        stage_idx=stage_idx,
+        ratio=ratio,
+        old_sigma=old_sigma,
+        new_sigma=aligned_sigma(old_sigma, ratio)[1],
+        source_thw=source_thw,
+        target_thw=target_thw,
+    )
+
+
+def test_on_transition_projects_history_and_rebases_sigmas():
+    handle = create_res_multistep_sampler_handle()
+    video, audio = _known_video(), _known_audio()
+    handle.state.old_denoised = _Nested([video, audio])
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.6
+    transition = _transition((2, 4, 4), (4, 8, 8), ratio=2.0, old_sigma=0.5)
+
+    handle.on_transition(transition)
+
+    projected_video, projected_audio = handle.state.old_denoised.unbind()
+    assert projected_video.shape == (1, 1, 4, 8, 8)
+    assert projected_audio is audio
+    assert handle.state.old_sigma_down == pytest.approx(transition.new_sigma)
+    assert handle.state.prev_sigma_in == pytest.approx(aligned_sigma(0.6, 2.0)[1])
+
+
+def test_on_transition_leaves_empty_state_alone():
+    """No completed RES interval yet: the hook must preserve empty state and
+    create no history."""
+    handle = create_res_multistep_sampler_handle()
+    handle.on_transition(_transition((2, 4, 4), (4, 8, 8)))
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None
+
+
+def test_on_transition_never_touches_reentry_or_conditioning_tensors():
+    """The hook owns history only: noisy re-entry tensors and conditioning
+    tensors must be byte-identical after the call."""
+    reentry = torch.randn(1, 1, 2, 4, 4)
+    conditioning = torch.randn(1, 1, 2, 4, 4)
+    reentry_snapshot = reentry.clone()
+    conditioning_snapshot = conditioning.clone()
+    handle = create_res_multistep_sampler_handle()
+    handle.state.old_denoised = _Nested([_known_video(), _known_audio()])
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.6
+
+    handle.on_transition(_transition((2, 4, 4), (4, 8, 8)))
+
+    assert torch.equal(reentry, reentry_snapshot)
+    assert torch.equal(conditioning, conditioning_snapshot)
+
+
+def test_on_transition_twice_at_coincident_boundary_no_new_history():
+    """Two boundaries at the same scheduler index: the hook runs for both,
+    history is re-projected to the final geometry, sigma metadata reflects
+    both rebases, and no synthetic new old_denoised is created. Resetting to
+    first order (clearing state) would change the next stage's trajectory,
+    so history must survive both hooks."""
+    handle = create_res_multistep_sampler_handle()
+    video, audio = _known_video(), _known_audio()
+    handle.state.old_denoised = _Nested([video, audio])
+    handle.state.old_sigma_down = 0.5
+    handle.state.prev_sigma_in = 0.6
+
+    first = _transition((2, 4, 4), (4, 8, 8), ratio=2.0, old_sigma=0.5)
+    second = _transition((4, 8, 8), (4, 8, 8), ratio=1.5, old_sigma=first.new_sigma)
+    handle.on_transition(first)
+    handle.on_transition(second)
+
+    projected_video, projected_audio = handle.state.old_denoised.unbind()
+    assert projected_video.shape == (1, 1, 4, 8, 8)
+    assert projected_audio is audio
+    assert handle.state.old_sigma_down == pytest.approx(second.new_sigma)
+    expected_prev = aligned_sigma(aligned_sigma(0.6, 2.0)[1], 1.5)[1]
+    assert handle.state.prev_sigma_in == pytest.approx(expected_prev)

--- a/speed_scripts/tests/test_res_multistep_adapter.py
+++ b/speed_scripts/tests/test_res_multistep_adapter.py
@@ -352,10 +352,11 @@ def test_clean_projection_is_deterministic_and_shape_exact():
     assert torch.allclose(exact, source, atol=1e-5, rtol=0.0)
 
 
-def test_clean_projection_preserves_dtype_and_rejects_shrinking():
+def test_clean_projection_preserves_dtype_device_and_rejects_shrinking():
     source16 = _known_video().to(dtype=torch.float16)
     out16 = spectral_expand_clean_3d(source16, (3, 6, 6))
     assert out16.dtype == torch.float16
+    assert out16.device.type == source16.device.type
     with pytest.raises(ValueError):
         spectral_expand_clean_3d(_known_video(t=4, h=6, w=6), (2, 4, 4))
 
@@ -413,13 +414,17 @@ def test_rebase_sigmas_keeps_input_sigma_of_one():
 
 
 def test_rebase_sigmas_never_mutates_scheduler_data():
-    """The rebase is metadata-only: the caller's schedule tensor must come
-    out byte-identical."""
-    schedule = torch.tensor([1.0, 0.9, 0.5, 0.25, 0.0])
-    snapshot = schedule.clone()
-    state = ResMultistepState(old_sigma_down=0.5, prev_sigma_in=0.9)
-    rebase_res_history_sigmas(state, float(schedule[3]), 1.5)
-    assert torch.equal(schedule, snapshot)
+    """The rebase is metadata-only. The state's history tensor is aliased into
+    a schedule-like container standing in for scheduler-owned data: if the
+    rebase ever wrote through the tensor it holds, the alias would surface
+    the write and fail the byte-identical check."""
+    schedule_like = {"boundary": torch.tensor([1.0, 0.9, 0.5, 0.25, 0.0])}
+    snapshot = schedule_like["boundary"].clone()
+    state = ResMultistepState(
+        old_sigma_down=0.5, prev_sigma_in=0.9, old_denoised=schedule_like["boundary"],
+    )
+    rebase_res_history_sigmas(state, float(schedule_like["boundary"][3]), 1.5)
+    assert torch.equal(schedule_like["boundary"], snapshot)
 
 
 # ---------------------------------------------------------------------------
@@ -465,14 +470,15 @@ def test_on_transition_leaves_empty_state_alone():
 
 
 def test_on_transition_never_touches_reentry_or_conditioning_tensors():
-    """The hook owns history only: noisy re-entry tensors and conditioning
-    tensors must be byte-identical after the call."""
+    """The hook owns history only. The noisy re-entry and conditioning tensors
+    are aliased into the history itself: any write-through on the stored
+    history would surface in the aliases and fail the byte-identical check."""
     reentry = torch.randn(1, 1, 2, 4, 4)
     conditioning = torch.randn(1, 1, 2, 4, 4)
     reentry_snapshot = reentry.clone()
     conditioning_snapshot = conditioning.clone()
     handle = create_res_multistep_sampler_handle()
-    handle.state.old_denoised = _Nested([_known_video(), _known_audio()])
+    handle.state.old_denoised = _Nested([reentry, conditioning])
     handle.state.old_sigma_down = 0.5
     handle.state.prev_sigma_in = 0.6
 

--- a/speed_scripts/tests/test_res_multistep_runtime.py
+++ b/speed_scripts/tests/test_res_multistep_runtime.py
@@ -495,7 +495,7 @@ def test_failure_during_res_history_projection_clears_res_state(monkeypatch):
     handle, captured = _inject_res_handle(monkeypatch)
     calls = []
 
-    def exploding_project(history, target_thw):
+    def exploding_project(history, target_thw, source_stream_shapes=None):
         calls.append(1)
         raise RuntimeError("history projection exploded")
 

--- a/speed_scripts/tests/test_res_multistep_runtime.py
+++ b/speed_scripts/tests/test_res_multistep_runtime.py
@@ -1,0 +1,653 @@
+"""RES Multistep through the real SPEED runtime (plan S7 §20-§24, §31 steps 42-46).
+
+B1/B2 pinned the adapter and the transition hook in isolation; this module
+runs ``res_multistep`` through ``run_speed_pipeline`` — the real stage loop,
+the real transition call site, and the real cleanup chain — with the §13
+run-scoped handle injected at the runtime's handle factory (the same seam
+the S6 lifecycle tests use; ``res_multistep`` joins the public selector only
+at plan step 50).
+
+The conftest ``NestedTensor`` stub that ``h3_runtime.pack_latent`` builds has
+no tensor operations, so the guider below unwraps stage tensors into an
+arithmetic-capable nested pair before the sampler runs and wraps the result
+back — mirroring the real host nested-tensor contract the adapter is written
+against. The guider executes the sampler object the runtime hands it, so
+every interval runs the real stateful RES adapter and the carried
+``ResMultistepState`` can be inspected at each stage entry.
+"""
+
+import pytest
+import torch
+
+import speed_scripts.h3_runtime as h3_runtime
+import speed_scripts.res_multistep_adapter as res_multistep_adapter
+from conftest import (
+    LADDER_BOUNDARIES,
+    RecordingEchoGuider,
+    SeededRandomNoise,
+    make_latent,
+    make_nested,
+)
+from speed_scripts.automatic_config import STAGES_TO_SCALES
+from speed_scripts.config import SpeedConfig
+from speed_scripts.flow import aligned_sigma
+from speed_scripts.h3_runtime import _LW_ATTR, run_speed_pipeline
+from speed_scripts.res_multistep_adapter import (
+    ResMultistepSampler,
+    project_clean_history,
+)
+from speed_scripts.sampler_support import create_res_multistep_sampler_handle
+
+SIGMAS = torch.tensor([1.0, .9, .8, .7, .6, .5, .4, .3, .2, .1, 0.0])
+
+
+class ComputedNested:
+    """Arithmetic-capable nested H3 stand-in (video [B,C,T,H,W] + audio).
+
+    Same unbind/is_nested contract as the host nested tensor, plus the
+    tensor operations the RES solver applies to the working state
+    (add/sub/mul/div against floats and 0-dim schedule tensors).
+    """
+
+    is_nested = True
+
+    def __init__(self, streams):
+        self.streams = list(streams)
+
+    def unbind(self):
+        return list(self.streams)
+
+    def _pair(self, other, fn):
+        if isinstance(other, ComputedNested):
+            parts = other.streams
+        else:
+            parts = [other] * len(self.streams)
+        return ComputedNested([fn(a, b) for a, b in zip(self.streams, parts)])
+
+    def __add__(self, other):
+        return self._pair(other, lambda a, b: a + b)
+
+    def __radd__(self, other):
+        return self._pair(other, lambda a, b: b + a)
+
+    def __sub__(self, other):
+        return self._pair(other, lambda a, b: a - b)
+
+    def __rsub__(self, other):
+        return self._pair(other, lambda a, b: b - a)
+
+    def __mul__(self, other):
+        return self._pair(other, lambda a, b: a * b)
+
+    def __rmul__(self, other):
+        return self._pair(other, lambda a, b: b * a)
+
+    def __truediv__(self, other):
+        return self._pair(other, lambda a, b: a / b)
+
+
+class _Snapshot:
+    """What the run-scoped RES state held when one stage began."""
+
+    def __init__(self, state):
+        video, audio = state.old_denoised.unbind()
+        self.video = video
+        self.audio = audio
+        self.old_sigma_down = state.old_sigma_down
+        self.prev_sigma_in = state.prev_sigma_in
+
+
+class ResExecGuider(RecordingEchoGuider):
+    """Echo guider that actually executes the sampler object it receives.
+
+    ``RecordingEchoGuider`` never calls the sampler, so a stateful RES run
+    would look like a no-op. This guider hands the received sampler object
+    (the runtime handle's real ``ResMultistepSampler``) the stage noise and
+    zero latent as arithmetic nested pairs, records one state snapshot per
+    stage entry, counts model evaluations, keeps every denoised estimate the
+    model produced, and wraps the sampler output back into the stub nested
+    container the runtime unpacks.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.model_evals = 0
+        self.model_outputs = []
+        self.stage_entries = []
+
+    def _model(self):
+        guider = self
+
+        class _Model:
+            def __call__(self, x, sigma, **extra):
+                guider.model_evals += 1
+                s = float(sigma)
+                video, audio = x.unbind()
+                denoised = ComputedNested([
+                    video * 0.7 + 0.3 * (s / (1.0 + s)),
+                    audio * 0.8 + 0.02 * (s / (1.0 + s)),
+                ])
+                guider.model_outputs.append(denoised)
+                return denoised
+
+        return _Model()
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        self.samplers.append(sampler)
+        self.sigma_calls.append([float(s) for s in sigmas])
+        pub_video, pub_audio = list(noise.unbind())
+        self.noise_shapes.append(tuple(pub_video.shape))
+        state = getattr(sampler, "state", None)
+        if state is not None and state.old_denoised is not None:
+            self.stage_entries.append(_Snapshot(state))
+        else:
+            self.stage_entries.append(None)
+        x = ComputedNested(list(latent_image.unbind()))
+        run_noise = ComputedNested([pub_video, pub_audio])
+        count = len(sigmas) - 1
+
+        adapted = None
+        if callback is not None:
+            def adapted(entry):
+                # One native per-interval dict -> one legacy 4-arg callback,
+                # the same adaptation every native sampler callback gets.
+                callback(entry["i"], entry["denoised"], entry["x"], count)
+        out = sampler(
+            self._model(), run_noise, sigmas,
+            extra_args=None, callback=adapted, disable=True,
+        )
+        out_video, out_audio = out.unbind()
+        return make_nested(out_video, out_audio)
+
+
+def _inject_res_handle(monkeypatch):
+    """Route the runtime's handle factory to one fresh run-scoped RES handle.
+
+    The §13 seam: the stage loop only ever talks to a ``SpeedSamplerHandle``.
+    Until plan step 50 promotes ``res_multistep`` into the public selector,
+    the tests inject the handle the §13 factory builds — the exact object
+    production will build. The factory records the sampler name each run
+    requests, so every test can prove the runtime actually asked for
+    ``res_multistep`` instead of silently receiving a patched-in handle.
+    Returns ``(handle, captured)``; ``captured`` accumulates one
+    ``(name, handle)`` entry per run built on this patch.
+    """
+    handle = create_res_multistep_sampler_handle()
+    captured = []
+
+    def factory(name):
+        captured.append((name, handle))
+        return handle
+
+    monkeypatch.setattr(h3_runtime, "create_speed_sampler_handle", factory)
+    return handle, captured
+
+
+def _assert_res_seam(captured, handle):
+    """The runtime requested ``res_multistep`` and got this run-scoped handle."""
+    assert captured == [("res_multistep", handle)]
+
+
+def _run_res(cfg, guider, monkeypatch, **kwargs):
+    handle, captured = _inject_res_handle(monkeypatch)
+    out, denoised = run_speed_pipeline(
+        SeededRandomNoise(), guider, SIGMAS, make_latent(), cfg,
+        sampler_name="res_multistep", disable_pbar=True, **kwargs,
+    )
+    _assert_res_seam(captured, handle)  # one run-scoped handle per run
+    return handle, out, denoised
+
+
+def _explicit_ladder_cfg(stages, **overrides):
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=LADDER_BOUNDARIES[stages],
+        transition_mode="explicit",
+        **overrides,
+    )
+
+
+def _automatic_calibrated_cfg(stages):
+    """The Automatic node's delta_custom config: both transitions quantize
+    onto schedule index 1, so the middle stage gets a single-sigma schedule
+    (zero denoising steps) — the legal coincident-boundary case."""
+    return SpeedConfig(
+        scales=STAGES_TO_SCALES[stages],
+        transition_steps=tuple(range(1, len(STAGES_TO_SCALES[stages]))),
+        transition_mode="delta_custom",
+        delta=.005,
+        noise_amplitude=12.105,
+        noise_decay_exponent=.773,
+        full_latent_h=8,
+        full_latent_w=8,
+    )
+
+
+def _interval_counts(stages):
+    bounds = LADDER_BOUNDARIES[stages]
+    edges = (0,) + bounds + (len(SIGMAS) - 1,)
+    return [b - a for a, b in zip(edges[:-1], edges[1:])]
+
+
+def _assert_full_res_nested(latent):
+    video, audio = latent["samples"].unbind()
+    assert video.ndim == 5 and audio.ndim == 4
+    assert tuple(video.shape[-2:]) == (8, 8)
+
+
+def _stage_geometry(stages, stage_idx):
+    """(t, h, w) the ladder runs stage ``stage_idx`` at (no temporal scaling)."""
+    scale = STAGES_TO_SCALES[stages][stage_idx]
+    return (2, max(1, round(8 * scale)), max(1, round(8 * scale)))
+
+
+def _assert_res_state_cleared(handle):
+    assert handle.state.old_denoised is None
+    assert handle.state.old_sigma_down is None
+    assert handle.state.prev_sigma_in is None
+
+
+# ---------------------------------------------------------------------------
+# §20 runtime completion — 2/3/4-stage ladders through the real adapter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_res_stage_ladder_completes_at_full_resolution(monkeypatch, stages):
+    guider = ResExecGuider()
+    handle, out, denoised = _run_res(_explicit_ladder_cfg(stages), guider, monkeypatch)
+
+    assert len(guider.sigma_calls) == stages
+    # Every global denoising interval ran through the real stateful adapter
+    # (one model evaluation per interval).
+    assert guider.model_evals == len(SIGMAS) - 1
+    # Every stage received the SAME run-scoped sampler object.
+    assert guider.samplers == [guider.samplers[0]] * stages
+    assert isinstance(guider.samplers[0], ResMultistepSampler)
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # Walker and RES handle cleanup both succeeded on the success path.
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_res_state_cleared(handle)
+
+
+# ---------------------------------------------------------------------------
+# §22 RES progress — one callback per outer interval
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_res_callback_count_equals_global_denoising_intervals(monkeypatch, stages):
+    seen = []
+    guider = ResExecGuider()
+    _run_res(
+        _explicit_ladder_cfg(stages), guider, monkeypatch,
+        preview_callback=lambda step, x0, x, total: seen.append((step, total)),
+    )
+    # The ladder tiles the 10-interval schedule; RES adds no callbacks of its
+    # own, so the runtime sees exactly one per global interval.
+    assert seen == [(i, 10) for i in range(10)]
+
+
+# ---------------------------------------------------------------------------
+# §20 state transport — configured transitions carried through state,
+# alignment rebase exercised across stage boundaries
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stages", (2, 3, 4))
+def test_res_state_is_carried_and_rebased_across_stage_boundaries(monkeypatch, stages):
+    """At every stage boundary k the carried state must hold
+    ``old_sigma_down == new_q`` and ``prev_sigma_in`` equal to the last
+    interval's input sigma mapped through ``aligned_sigma`` with that
+    boundary's ratio, with the video history already projected to the next
+    stage's geometry. All expected values are computed independently from
+    the schedule and the scale ladder."""
+    guider = ResExecGuider()
+    _run_res(_explicit_ladder_cfg(stages), guider, monkeypatch)
+
+    bounds = LADDER_BOUNDARIES[stages]
+    scales = STAGES_TO_SCALES[stages]
+    entries = guider.stage_entries
+    assert entries[0] is None  # a fresh run starts with empty history
+    for k in range(1, stages):
+        boundary = bounds[k - 1]
+        ratio = scales[k] / scales[k - 1]
+        new_q = aligned_sigma(float(SIGMAS[boundary]), ratio)[1]
+        last_input = float(SIGMAS[boundary - 1])
+        snap = entries[k]
+        assert snap is not None
+        assert snap.old_sigma_down == pytest.approx(new_q, rel=1e-6)
+        assert snap.prev_sigma_in == pytest.approx(
+            aligned_sigma(last_input, ratio)[1], rel=1e-6
+        )
+        # History video was projected to the next stage's geometry; the
+        # clean audio estimate kept its shape and is nonzero.
+        assert tuple(snap.video.shape[-3:]) == _stage_geometry(stages, k)
+        assert tuple(snap.audio.shape) == (1, 1, 2, 44)
+        assert snap.audio.abs().sum() > 0
+        # §21: the clean history audio object is the model's own estimate —
+        # passed through the boundary untouched, never clock-reindexed.
+        intervals_before = sum(_interval_counts(stages)[:k])
+        assert snap.audio is guider.model_outputs[intervals_before - 1].unbind()[1]
+
+
+# ---------------------------------------------------------------------------
+# §20 noise policies — direct_coarse and coupled_full_grid
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("noise_policy", ("direct_coarse", "coupled_full_grid"))
+def test_res_runtime_completes_under_noise_policy(monkeypatch, noise_policy):
+    guider = ResExecGuider()
+    handle, out, denoised = _run_res(
+        _explicit_ladder_cfg(2, noise_policy=noise_policy), guider, monkeypatch,
+    )
+
+    assert len(guider.sigma_calls) == 2
+    assert guider.model_evals == len(SIGMAS) - 1
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # The boundary rebase ran under this noise policy too.
+    snap = guider.stage_entries[1]
+    assert snap is not None
+    boundary = LADDER_BOUNDARIES[2][0]  # the (0.5 -> 1.0) ladder's boundary
+    ratio = STAGES_TO_SCALES[2][1] / STAGES_TO_SCALES[2][0]
+    assert snap.old_sigma_down == pytest.approx(
+        aligned_sigma(float(SIGMAS[boundary]), ratio)[1], rel=1e-6
+    )
+    assert snap.prev_sigma_in == pytest.approx(
+        aligned_sigma(float(SIGMAS[boundary - 1]), ratio)[1], rel=1e-6
+    )
+    assert tuple(snap.video.shape[-3:]) == (2, 8, 8)
+    _assert_res_state_cleared(handle)  # run-level cleanup ran
+
+
+def test_res_noise_policies_produce_different_runs(monkeypatch):
+    """The two policies must actually diverge (the coupled policy feeds the
+    full-grid noise projection instead of fresh coarse noise), so passing
+    one for the other cannot hide behind identical outputs."""
+    outs = []
+    for policy in ("direct_coarse", "coupled_full_grid"):
+        guider = ResExecGuider()
+        _, out, _ = _run_res(
+            _explicit_ladder_cfg(2, noise_policy=policy), guider, monkeypatch,
+        )
+        video, _ = out["samples"].unbind()
+        outs.append(video)
+    assert not torch.equal(outs[0], outs[1])
+
+
+# ---------------------------------------------------------------------------
+# §24 RES I2V smoke — walker restore, pristine conds, history separate from
+# conditioning
+# ---------------------------------------------------------------------------
+
+def _i2v_guider(guider_cls=ResExecGuider):
+    """Guider with real I2V-shaped (nonzero) conditioning attached.
+
+    Returns (guider, keyframes, refs, pristine) where pristine holds a clone
+    of every keyframe latent for the restore assertions.
+    """
+    guider = guider_cls()
+    g = torch.Generator().manual_seed(5)
+    keyframes = [
+        {"latent": torch.randn(1, 1, 2, 8, 8, generator=g)} for _ in range(2)
+    ]
+    refs = [{"latent": torch.randn(1, 1, 2, 8, 8, generator=g)} for _ in range(2)]
+    pristine = [kf["latent"].clone() for kf in keyframes]
+    guider.original_conds = {
+        "positive": [{
+            "minimax_keyframes": keyframes,
+            "minimax_refs": refs,
+        }],
+        "negative": [],
+    }
+    return guider, keyframes, refs, pristine
+
+
+def _assert_pristine_conds(keyframes, refs, pristine):
+    for kf, saved in zip(keyframes, pristine):
+        assert torch.equal(kf["latent"], saved)
+    for ref in refs:
+        assert tuple(ref["latent"].shape[-2:]) == (8, 8)
+
+
+def test_res_i2v_smoke_restores_pristine_and_keeps_history_separate(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    _, out, denoised = _run_res(_explicit_ladder_cfg(3), guider, monkeypatch)
+
+    _assert_full_res_nested(out)
+    _assert_full_res_nested(denoised)
+    # Walker restore: keyframe latents came back to pristine full-res values,
+    # refs were never resized, and no sampler code rebuilt the cond containers.
+    _assert_pristine_conds(keyframes, refs, pristine)
+    assert not hasattr(guider, _LW_ATTR)
+    # §24: RES history projection is separate from I2V conditioning
+    # projection — the final stage entered with projected solver history
+    # that is no conditioning latent.
+    snap = guider.stage_entries[-1]
+    assert snap is not None
+    assert snap.video.abs().sum() > 0
+    for holder in keyframes + refs:
+        assert snap.video is not holder["latent"]
+        assert not torch.equal(snap.video, holder["latent"])
+
+
+# ---------------------------------------------------------------------------
+# §20 failure/cleanup — every failure point clears RES state, closes the
+# handle, and still runs the walker cleanup through the nested finally chain
+# ---------------------------------------------------------------------------
+
+class ExplodingAtStage2(ResExecGuider):
+    """Fails inside the third guider.sample call (the final stage)."""
+
+    def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+        if len(self.sigma_calls) == 2:
+            raise RuntimeError("sampler call exploded")
+        return super().sample(
+            noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+        )
+
+
+def test_failure_during_sampler_call_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider(ExplodingAtStage2)
+    handle, captured = _inject_res_handle(monkeypatch)
+    with pytest.raises(RuntimeError, match="sampler call exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(3),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    # Two stages had run: RES history existed mid-run, so the cleared state
+    # below proves the close, not an empty run.
+    assert len(guider.stage_entries) == 2
+    assert guider.stage_entries[1] is not None
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+def test_failure_during_spectral_transition_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    handle, captured = _inject_res_handle(monkeypatch)
+    observed = {}
+
+    def exploding_expand(value, target_hw, sigma, seed):
+        # Observed at the moment of explosion: stage 0 had completed real
+        # intervals, so solver history existed when the transition failed.
+        observed["history_existed"] = handle.state.old_denoised is not None
+        raise RuntimeError("spectral transition exploded")
+
+    monkeypatch.setattr(h3_runtime, "spectral_expand", exploding_expand)
+    with pytest.raises(RuntimeError, match="spectral transition exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(2),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    assert observed["history_existed"] is True
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+def test_failure_during_res_history_projection_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    handle, captured = _inject_res_handle(monkeypatch)
+    calls = []
+
+    def exploding_project(history, target_thw):
+        calls.append(1)
+        raise RuntimeError("history projection exploded")
+
+    monkeypatch.setattr(
+        res_multistep_adapter, "project_clean_history", exploding_project
+    )
+    with pytest.raises(RuntimeError, match="history projection exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(2),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    # The hook only calls the projection when history exists, so the call
+    # itself proves stage-0 history existed when the projection failed.
+    assert calls == [1]
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+def test_failure_during_audio_transition_clears_res_state(monkeypatch):
+    guider, keyframes, refs, pristine = _i2v_guider()
+    handle, captured = _inject_res_handle(monkeypatch)
+    observed = {}
+
+    def exploding_reindex(*args, **kwargs):
+        # Observed at the moment of explosion: history existed when the
+        # audio handling failed (same first boundary as the spectral case).
+        observed["history_existed"] = handle.state.old_denoised is not None
+        raise RuntimeError("audio transition exploded")
+
+    monkeypatch.setattr(h3_runtime, "clock_reindex_audio_state", exploding_reindex)
+    with pytest.raises(RuntimeError, match="audio transition exploded"):
+        run_speed_pipeline(
+            SeededRandomNoise(), guider, SIGMAS, make_latent(),
+            _explicit_ladder_cfg(2),
+            sampler_name="res_multistep", disable_pbar=True,
+        )
+    _assert_res_seam(captured, handle)
+    assert observed["history_existed"] is True
+    _assert_res_state_cleared(handle)
+    assert not hasattr(guider, _LW_ATTR)
+    _assert_pristine_conds(keyframes, refs, pristine)
+
+
+# ---------------------------------------------------------------------------
+# §20 state-leak — a fresh RES run after a completed RES run starts clean
+# ---------------------------------------------------------------------------
+
+def test_res_second_generation_after_completed_run_starts_clean(monkeypatch):
+    cfg = _explicit_ladder_cfg(3)
+    guider = ResExecGuider()
+
+    handle_1, out_1, _ = _run_res(cfg, guider, monkeypatch)
+    _assert_res_state_cleared(handle_1)
+
+    handle_2, out_2, _ = _run_res(cfg, guider, monkeypatch)
+    # Same guider object, but a brand-new run-scoped handle: state is never
+    # reused between queue executions.
+    assert handle_2 is not handle_1
+    # The second generation's first stage started from empty history —
+    # nothing leaked from the completed first run.
+    assert guider.stage_entries[3] is None
+    # ... and the whole second trajectory is identical to the first
+    # (deterministic engine, no carried-over corruption).
+    video_1, audio_1 = out_1["samples"].unbind()
+    video_2, audio_2 = out_2["samples"].unbind()
+    assert torch.equal(video_1, video_2)
+    assert torch.equal(audio_1, audio_2)
+
+    # Control: a fresh guider produces the same output bit-for-bit.
+    control = ResExecGuider()
+    _, out_control, _ = _run_res(cfg, control, monkeypatch)
+    video_c, audio_c = out_control["samples"].unbind()
+    assert torch.equal(video_2, video_c)
+    assert torch.equal(audio_2, audio_c)
+    assert not hasattr(guider, _LW_ATTR)
+
+
+# ---------------------------------------------------------------------------
+# §23 zero-step torture — coincident boundaries through the real runtime
+# ---------------------------------------------------------------------------
+
+def test_res_coincident_boundary_zero_step_stages_preserve_history(monkeypatch):
+    """Both transitions quantize onto schedule index 1: stage 1 runs zero
+    denoising steps. The zero-step stage must not update solver history, the
+    transition hooks must still project/rebase it (twice, without corruption),
+    and the final stage must enter with valid history so it can resume
+    second-order behavior."""
+    guider = ResExecGuider()
+    _, out, _ = _run_res(_automatic_calibrated_cfg(3), guider, monkeypatch)
+
+    assert len(guider.sigma_calls) == 3
+    assert len(guider.sigma_calls[1]) == 1  # zero-step middle stage
+    # Model ran 1 + 0 + 9 intervals: the zero-step stage added no history.
+    assert guider.model_evals == len(SIGMAS) - 1
+
+    first = guider.model_outputs[0]
+    entries = guider.stage_entries
+    # Hook 1 projected stage-0 history to stage 1's geometry and rebased
+    # both sigma fields (prev_sigma_in == 1.0 stays 1.0 — legal history).
+    snap1 = entries[1]
+    assert snap1 is not None
+    assert tuple(snap1.video.shape[-3:]) == _stage_geometry(3, 1)
+    assert snap1.old_sigma_down == pytest.approx(
+        aligned_sigma(float(SIGMAS[1]), 2.0)[1], rel=1e-6
+    )
+    assert snap1.prev_sigma_in == pytest.approx(1.0)
+
+    # Hook 2 ran on the unchanged history (zero intervals in between):
+    # the result equals the independent double projection, and the clean
+    # audio estimate is still the very same tensor the model produced.
+    snap2 = entries[2]
+    expected = project_clean_history(
+        project_clean_history(first, _stage_geometry(3, 1)),
+        _stage_geometry(3, 2),
+    )
+    expected_video = expected.unbind()[0]
+    assert torch.equal(snap2.video, expected_video)
+    assert snap2.audio is first.unbind()[1]
+    assert snap2.audio.abs().sum() > 0
+    # Sigma metadata reflects both rebases.
+    chained = aligned_sigma(float(SIGMAS[1]), 2.0)[1]
+    assert snap2.old_sigma_down == pytest.approx(
+        aligned_sigma(chained, 1.5)[1], rel=1e-6
+    )
+    assert snap2.prev_sigma_in == pytest.approx(1.0)
+    # Valid history at the final stage: second-order RES can resume.
+    assert snap2.old_sigma_down != pytest.approx(snap2.prev_sigma_in)
+    _assert_full_res_nested(out)
+    assert not hasattr(guider, _LW_ATTR)
+
+
+def test_res_final_stage_second_order_behavior_depends_on_carried_history(monkeypatch):
+    """The §23 precondition alone (history differs from the input sigma) is
+    not proof: with carried history the final stage's intervals must follow
+    a different trajectory than the documented §15/§28 test-only reset
+    control — history cleared at the boundary, through the real runtime.
+    A run that silently reset history at the boundary would match the
+    control and fail this test."""
+    cfg = _explicit_ladder_cfg(2)
+
+    class ResetAtBoundary(ResExecGuider):
+        def sample(self, noise, latent_image, sampler, sigmas, callback=None, **kwargs):
+            if len(self.sigma_calls) == 1:  # the final stage call
+                sampler.state.clear()  # test-only reset-history control
+            return super().sample(
+                noise, latent_image, sampler, sigmas, callback=callback, **kwargs
+            )
+
+    _, out_carried, _ = _run_res(cfg, ResExecGuider(), monkeypatch)
+    handle_reset, out_reset, _ = _run_res(cfg, ResetAtBoundary(), monkeypatch)
+    assert handle_reset.state.old_denoised is None
+    assert not torch.equal(out_carried["samples"].unbind()[0], out_reset["samples"].unbind()[0])


### PR DESCRIPTION
# SPEED top-5 samplers (PR B): RES Multistep — stateful adapter, stacked on PR A

Draft, stacked on PR A (`feature/top5-samplers` → `dev`, #50). Do not merge until PR A lands; retarget to `dev` afterwards.

## What shipped (plan S7 §11-24)

Original stateful RES Multistep adapter for the MiniMax-H3 SPEED chain, built as an original implementation (no GPL text, no provenance markers):

- `ResMultistepState` — deterministic, no RNG, per-run state object stashed on the guider and dropped at run end (no state leaks across runs; covered by state-leak tests).
- RES step semantics per S7 §11-14: `t_prev` comes from the state (no `sigmas[i-1]` read), no stage-local `sigmas[-1]`, single-sigma stage is a pinned no-op, `on_transition` fires at the exact §7 plan position (`h3_runtime.py:610`, after patch + transitions, before re-entry).
- Clean-history projection: `spectral_expand_clean_3d` (deterministic zero-padded clean DCT projection) and `project_clean_history` (video-only projection, clean audio untouched).
- Sigma rebase: when the stage ladder changes the sigma grid, the adapter re-derives `t_prev` from the new grid instead of trusting stale history.
- Tests: `speed_scripts/tests/test_res_multistep_runtime.py` (20 tests) runs res_multistep through the real `run_speed_pipeline` stage loop via the §13 handle-factory seam — runtime, noise-policy, I2V, cleanup, and state-leak coverage. Adapter math verified numerically identical to native ComfyUI `res_multistep` at eta=0 (independent transcription, max abs diff 3.6e-07).

## Acceptance table (S7 §30 sweep, from B4)

Full suite at this tip: **196 passed, 0 failed (0.97s)**, repo venv, Python 3.13.5.

| # | Item | Status |
|---|------|--------|
| 1 | Original implementation, no GPL text, no provenance markers | LOCAL-PASS |
| 2 | Adapter math == native `res_multistep` eta=0 (ind. transcription, max diff 3.6e-07) | LOCAL-PASS |
| 3 | `ResMultistepState` deterministic, no RNG | LOCAL-PASS |
| 4 | State semantics §11-14: `t_prev` from state, no `sigmas[i-1]`, no `sigmas[-1]` | LOCAL-PASS |
| 5 | Single-sigma stage is a no-op (pinned) | LOCAL-PASS |
| 6 | `on_transition` at exact §7 position | LOCAL-PASS |
| 7 | Clean-history projection deterministic | LOCAL-PASS |
| 8 | Sigma rebase on stage transition | LOCAL-PASS |
| 9 | Transition hook wired through `run_speed_pipeline` | LOCAL-PASS |
| 10 | Noise policy honored inside adapter | LOCAL-PASS |
| 11 | I2V path works with RES adapter | LOCAL-PASS |
| 12 | Cleanup: state dropped at run end | LOCAL-PASS |
| 13 | State-leak: no cross-run contamination | LOCAL-PASS |
| 14 | Oracles: per-field mutation sensitivity + reset negative control + double-projection composition | LOCAL-PASS |
| 15 | Public surface clean: `SUPPORTED_SPEED_SAMPLERS` = 4 stateless names | LOCAL-PASS |
| 16 | `res_multistep` fail-closed (raises if requested, not in selector) | LOCAL-PASS |
| 17 | Docs truthful (README/AGENTS wording) | LOCAL-PASS |
| 27 | Real-H3 visual sanity (standard) | USER-GATE |
| 28 | Real-H3 visual sanity (8-step Turbo + SageAttention) | USER-GATE |
| 27b | §27 benchmark | USER-GATE |
| 28b | §28 benchmark | USER-GATE |

17 items LOCAL-PASS with test evidence, 0 FAIL, 2 USER-GATE (real H3 visual sanity), benchmarks USER-GATE, 1 deferred by design (5th sampler — this PR).

## Real-H3 checks the GPU box must run before the public flip

1. Standard real-H3 RES validation: full multi-stage SPEED run with `res_multistep` enabled on the real checkpoint, visually compared against native `res_multistep` eta=0.
2. 8-step Turbo / SageAttention RES validation: same run with the 8-step Turbo checkpoint and SageAttention enabled, confirm no crash at transitions and output quality parity.
3. §27 / §28 benchmarks: latency vs native `res_multistep` and vs the 4 stateless SPEED samplers.

## Public selector status (explicit)

`"res_multistep"` is **NOT** in the public selector. `SUPPORTED_SPEED_SAMPLERS` still contains exactly 4 stateless names; requesting `res_multistep` fails closed. This is deliberate: the public flip is a post-validation step, not part of this PR.

Precise follow-up flip line (only after ALL §30 gates pass, including the USER-GATE items above):

> Append `"res_multistep"` to `SUPPORTED_SPEED_SAMPLERS` ONLY after all §30 gates pass (17 LOCAL-PASS re-confirmed at merge tip + real-H3 standard validation + 8-step Turbo/SageAttention validation + §27/§28 benchmarks). This is a deliberate post-validation step.

## Merge order

1. PR A first: #50 (`feature/top5-samplers` → `dev`).
2. This PR is STACKED on `feature/top5-samplers`. After PR A merges, retarget this PR to `dev`.

## Docs status

README and AGENTS.md wording reflects deferred flip: they describe 4 supported samplers and explicitly note `res_multistep` is gated behind post-validation. No docs claim the 5th sampler is publicly selectable.
